### PR TITLE
Feat/#84 get section list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,10 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/aws/retrospective/RetrospectiveApplication.java
+++ b/src/main/java/aws/retrospective/RetrospectiveApplication.java
@@ -1,7 +1,10 @@
 package aws.retrospective;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
@@ -11,5 +14,10 @@ public class RetrospectiveApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(RetrospectiveApplication.class, args);
 	}
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
 
 }

--- a/src/main/java/aws/retrospective/RetrospectiveApplication.java
+++ b/src/main/java/aws/retrospective/RetrospectiveApplication.java
@@ -1,10 +1,7 @@
 package aws.retrospective;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
@@ -14,10 +11,4 @@ public class RetrospectiveApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(RetrospectiveApplication.class, args);
 	}
-
-    @Bean
-    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
-        return new JPAQueryFactory(em);
-    }
-
 }

--- a/src/main/java/aws/retrospective/config/QuerydslConfig.java
+++ b/src/main/java/aws/retrospective/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package aws.retrospective.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/aws/retrospective/controller/SectionController.java
+++ b/src/main/java/aws/retrospective/controller/SectionController.java
@@ -6,6 +6,8 @@ import aws.retrospective.dto.CreateSectionResponseDto;
 import aws.retrospective.dto.DeleteSectionRequestDto;
 import aws.retrospective.dto.EditSectionRequestDto;
 import aws.retrospective.dto.EditSectionResponseDto;
+import aws.retrospective.dto.GetSectionsRequestDto;
+import aws.retrospective.dto.GetSectionsResponseDto;
 import aws.retrospective.dto.IncreaseSectionLikesRequestDto;
 import aws.retrospective.dto.IncreaseSectionLikesResponseDto;
 import aws.retrospective.service.SectionService;
@@ -14,9 +16,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -77,5 +81,12 @@ public class SectionController {
     public CommonApiResponse<Void> deleteSection(@PathVariable("sectionId") Long sectionId, @Valid @RequestBody DeleteSectionRequestDto request) {
         sectionService.deleteSection(sectionId, request);
         return CommonApiResponse.successResponse(HttpStatus.NO_CONTENT, null);
+    }
+
+    // 섹션 전체 조회
+    @GetMapping
+    public CommonApiResponse<List<GetSectionsResponseDto>> getSections(@RequestBody @Valid GetSectionsRequestDto request) {
+        List<GetSectionsResponseDto> response = sectionService.getSections(request);
+        return CommonApiResponse.successResponse(HttpStatus.OK, response);
     }
 }

--- a/src/main/java/aws/retrospective/dto/GetSectionsRequestDto.java
+++ b/src/main/java/aws/retrospective/dto/GetSectionsRequestDto.java
@@ -1,0 +1,14 @@
+package aws.retrospective.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class GetSectionsRequestDto {
+
+    @NotNull(message = "회고보드 id는 필수 값입니다.")
+    private Long retrospectiveId;
+
+    @NotNull(message = "팀 id는 필수 값입니다.")
+    private Long teamId;
+}

--- a/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
@@ -1,0 +1,17 @@
+package aws.retrospective.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetSectionsResponseDto {
+
+    private Long sectionId;
+    private String username;
+    private String content;
+    private long likeCnt;
+    private String sectionName;
+    private LocalDateTime createdDate;
+}

--- a/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
@@ -1,11 +1,10 @@
 package aws.retrospective.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class GetSectionsResponseDto {
 
     private Long sectionId;
@@ -14,4 +13,15 @@ public class GetSectionsResponseDto {
     private long likeCnt;
     private String sectionName;
     private LocalDateTime createdDate;
+
+    @QueryProjection
+    public GetSectionsResponseDto(Long sectionId, String username, String content, long likeCnt,
+        String sectionName, LocalDateTime createdDate) {
+        this.sectionId = sectionId;
+        this.username = username;
+        this.content = content;
+        this.likeCnt = likeCnt;
+        this.sectionName = sectionName;
+        this.createdDate = createdDate;
+    }
 }

--- a/src/main/java/aws/retrospective/exception/GlobalExceptionHandler.java
+++ b/src/main/java/aws/retrospective/exception/GlobalExceptionHandler.java
@@ -16,7 +16,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> validMissingParameterException(MethodArgumentNotValidException ex) {
         log.error("유효성 검사 실패", ex);
-        ErrorResponse response = new ErrorResponse(ErrorCode.MISSING_REQUEST_PARAMETER, ex.getMessage());
+        String errorMessage = ex.getBindingResult().getFieldError().getDefaultMessage();
+        ErrorResponse response = new ErrorResponse(ErrorCode.MISSING_REQUEST_PARAMETER, errorMessage);
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/aws/retrospective/repository/SectionRepository.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepository.java
@@ -11,15 +11,5 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface SectionRepository extends JpaRepository<Section, Long>, SectionRepositoryCustom {
 
-    @Query("select new aws.retrospective"
-        + ".dto.GetSectionsResponseDto(s.id, u.username, s.content, s.likeCnt, ts.sectionName, s.createdDate)"
-        + " from Section s"
-        + " join s.retrospective r"
-        + " join s.user u"
-        + " join s.templateSection ts"
-        + " where r.id = :retrospectiveId")
-    List<GetSectionsResponseDto> findSections(Long retrospectiveId);
     int countByRetrospectiveAndTemplateSection(Retrospective retrospective, TemplateSection templateSection);
-
-
 }

--- a/src/main/java/aws/retrospective/repository/SectionRepository.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepository.java
@@ -1,8 +1,19 @@
 package aws.retrospective.repository;
 
+import aws.retrospective.dto.GetSectionsResponseDto;
 import aws.retrospective.entity.Section;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
 
+    @Query("select new aws.retrospective"
+        + ".dto.GetSectionsResponseDto(s.id, u.username, s.content, s.likeCnt, ts.sectionName, s.createdDate)"
+        + " from Section s"
+        + " join s.retrospective r"
+        + " join s.user u"
+        + " join s.templateSection ts"
+        + " where r.id = :retrospectiveId")
+    List<GetSectionsResponseDto> findSections(Long retrospectiveId);
 }

--- a/src/main/java/aws/retrospective/repository/SectionRepository.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepository.java
@@ -9,7 +9,7 @@ import aws.retrospective.entity.TemplateSection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface SectionRepository extends JpaRepository<Section, Long> {
+public interface SectionRepository extends JpaRepository<Section, Long>, SectionRepositoryCustom {
 
     @Query("select new aws.retrospective"
         + ".dto.GetSectionsResponseDto(s.id, u.username, s.content, s.likeCnt, ts.sectionName, s.createdDate)"
@@ -20,4 +20,6 @@ public interface SectionRepository extends JpaRepository<Section, Long> {
         + " where r.id = :retrospectiveId")
     List<GetSectionsResponseDto> findSections(Long retrospectiveId);
     int countByRetrospectiveAndTemplateSection(Retrospective retrospective, TemplateSection templateSection);
+
+
 }

--- a/src/main/java/aws/retrospective/repository/SectionRepositoryCustom.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepositoryCustom.java
@@ -1,0 +1,9 @@
+package aws.retrospective.repository;
+
+import aws.retrospective.dto.GetSectionsResponseDto;
+import java.util.List;
+
+public interface SectionRepositoryCustom {
+
+    List<GetSectionsResponseDto> getSections(Long retrospectiveId);
+}

--- a/src/main/java/aws/retrospective/repository/SectionRepositoryCustomImpl.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepositoryCustomImpl.java
@@ -1,0 +1,33 @@
+package aws.retrospective.repository;
+
+import static aws.retrospective.entity.QRetrospective.retrospective;
+import static aws.retrospective.entity.QSection.section;
+import static aws.retrospective.entity.QTemplateSection.templateSection;
+import static aws.retrospective.entity.QUser.user;
+
+import aws.retrospective.dto.GetSectionsResponseDto;
+import aws.retrospective.dto.QGetSectionsResponseDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SectionRepositoryCustomImpl implements SectionRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<GetSectionsResponseDto> getSections(Long retrospectiveId) {
+        return queryFactory.
+            select(
+                new QGetSectionsResponseDto(section.id, user.username, section.content,
+                    section.likeCnt, templateSection.sectionName, section.createdDate))
+            .from(section)
+            .join(section.retrospective, retrospective)
+            .join(section.user, user)
+            .join(section.templateSection, templateSection)
+            .where(retrospective.id.eq(retrospectiveId))
+            .fetch();
+    }
+
+}

--- a/src/main/java/aws/retrospective/service/SectionService.java
+++ b/src/main/java/aws/retrospective/service/SectionService.java
@@ -1,10 +1,5 @@
 package aws.retrospective.service;
 
-import static aws.retrospective.entity.QRetrospective.retrospective;
-import static aws.retrospective.entity.QSection.section;
-import static aws.retrospective.entity.QTemplateSection.templateSection;
-import static aws.retrospective.entity.QUser.user;
-
 import aws.retrospective.dto.CreateSectionDto;
 import aws.retrospective.dto.CreateSectionResponseDto;
 import aws.retrospective.dto.DeleteSectionRequestDto;
@@ -16,7 +11,6 @@ import aws.retrospective.dto.GetSectionsRequestDto;
 import aws.retrospective.dto.GetSectionsResponseDto;
 import aws.retrospective.dto.IncreaseSectionLikesRequestDto;
 import aws.retrospective.dto.IncreaseSectionLikesResponseDto;
-import aws.retrospective.dto.QGetSectionsResponseDto;
 import aws.retrospective.entity.Likes;
 import aws.retrospective.entity.Retrospective;
 import aws.retrospective.entity.Section;
@@ -30,7 +24,6 @@ import aws.retrospective.repository.SectionRepository;
 import aws.retrospective.repository.TeamRepository;
 import aws.retrospective.repository.TemplateSectionRepository;
 import aws.retrospective.repository.UserRepository;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -48,7 +41,6 @@ public class SectionService {
     private final TemplateSectionRepository templateSectionRepository;
     private final LikesRepository likesRepository;
     private final TeamRepository teamRepository;
-    private final JPAQueryFactory queryFactory;
 
     // Section 등록
     @Transactional
@@ -193,16 +185,7 @@ public class SectionService {
             throw new ForbiddenAccessException("해당 팀의 회고보드만 조회할 수 있습니다.");
         }
 
-        return queryFactory.
-            select(
-                new QGetSectionsResponseDto(section.id, user.username, section.content,
-                    section.likeCnt, templateSection.sectionName, section.createdDate))
-            .from(section)
-            .join(section.retrospective, retrospective)
-            .join(section.user, user)
-            .join(section.templateSection, templateSection)
-            .where(retrospective.id.eq(request.getRetrospectiveId()))
-            .fetch();
+        return sectionRepository.getSections(request.getRetrospectiveId());
     }
 
     private Team getTeam(GetSectionsRequestDto request) {

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -23,10 +23,6 @@ import aws.retrospective.dto.IncreaseSectionLikesResponseDto;
 import aws.retrospective.dto.QGetSectionsResponseDto;
 import aws.retrospective.entity.Likes;
 import aws.retrospective.entity.ProjectStatus;
-import aws.retrospective.entity.QRetrospective;
-import aws.retrospective.entity.QSection;
-import aws.retrospective.entity.QTemplateSection;
-import aws.retrospective.entity.QUser;
 import aws.retrospective.entity.Retrospective;
 import aws.retrospective.entity.RetrospectiveTemplate;
 import aws.retrospective.entity.Section;
@@ -363,25 +359,25 @@ class SectionServiceTest {
     void notSearchRetrospective() {
         //given
         Long teamId = 1L;
-        Team team1 = createTeam();
-        ReflectionTestUtils.setField(team1, "id", teamId);
-        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team1));
+        Team createdTeam1 = createTeam();
+        ReflectionTestUtils.setField(createdTeam1, "id", teamId);
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(createdTeam1));
 
-        RetrospectiveTemplate template = createTemplate();
-        User user = createUser();
+        RetrospectiveTemplate createdTemplate = createTemplate();
+        User createdUser = createUser();
 
-        Team team2 = createTeam();
-        ReflectionTestUtils.setField(team1, "id", 2L);
+        Team createdTeam2 = createTeam();
+        ReflectionTestUtils.setField(createdTeam1, "id", 2L);
 
         Long retrospectiveId = 1L;
-        Retrospective retrospective = createRetrospective(template ,user, team2);
+        Retrospective createdRetrospective = createRetrospective(createdTemplate ,createdUser, createdTeam2);
         ReflectionTestUtils.setField(retrospective, "id", retrospectiveId);
-        when(retrospectiveRepository.findById(retrospectiveId)).thenReturn(Optional.of(retrospective));
+        when(retrospectiveRepository.findById(retrospectiveId)).thenReturn(Optional.of(createdRetrospective));
 
-        TemplateSection templateSection = createTemplateSection(template);
+        TemplateSection createdTemplateSection = createTemplateSection(createdTemplate);
 
         Long sectionId = 1L;
-        Section section = createSection(user, templateSection, retrospective);
+        Section createdSection = createSection(createdUser, createdTemplateSection, createdRetrospective);
         ReflectionTestUtils.setField(section, "id", sectionId);
 
         //when

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -371,14 +371,14 @@ class SectionServiceTest {
 
         Long retrospectiveId = 1L;
         Retrospective createdRetrospective = createRetrospective(createdTemplate ,createdUser, createdTeam2);
-        ReflectionTestUtils.setField(retrospective, "id", retrospectiveId);
+        ReflectionTestUtils.setField(createdRetrospective, "id", retrospectiveId);
         when(retrospectiveRepository.findById(retrospectiveId)).thenReturn(Optional.of(createdRetrospective));
 
         TemplateSection createdTemplateSection = createTemplateSection(createdTemplate);
 
         Long sectionId = 1L;
         Section createdSection = createSection(createdUser, createdTemplateSection, createdRetrospective);
-        ReflectionTestUtils.setField(section, "id", sectionId);
+        ReflectionTestUtils.setField(createdSection, "id", sectionId);
 
         //when
         GetSectionsRequestDto request = new GetSectionsRequestDto();

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -1,9 +1,5 @@
 package aws.retrospective.service;
 
-import static aws.retrospective.entity.QRetrospective.*;
-import static aws.retrospective.entity.QSection.*;
-import static aws.retrospective.entity.QTemplateSection.*;
-import static aws.retrospective.entity.QUser.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
@@ -20,7 +16,6 @@ import aws.retrospective.dto.GetSectionsRequestDto;
 import aws.retrospective.dto.GetSectionsResponseDto;
 import aws.retrospective.dto.IncreaseSectionLikesRequestDto;
 import aws.retrospective.dto.IncreaseSectionLikesResponseDto;
-import aws.retrospective.dto.QGetSectionsResponseDto;
 import aws.retrospective.entity.Likes;
 import aws.retrospective.entity.ProjectStatus;
 import aws.retrospective.entity.Retrospective;
@@ -319,22 +314,7 @@ class SectionServiceTest {
             createdTemplateSection.getSectionName(), createdSection.getCreatedDate()
         );
 
-        when(queryFactory.select(
-            new QGetSectionsResponseDto(section.id, user.username,
-                section.content,
-                section.likeCnt, templateSection.sectionName,
-                section.createdDate)))
-            .thenReturn(jpaQuery);
-        when(jpaQuery.from(section)).thenReturn(jpaQuery);
-        when(jpaQuery.join(section.retrospective, retrospective))
-            .thenReturn(jpaQuery);
-        when(jpaQuery.join(section.user, user))
-            .thenReturn(jpaQuery);
-        when(jpaQuery.join(section.templateSection, templateSection))
-            .thenReturn(jpaQuery);
-        when(jpaQuery.where(retrospective.id.eq(retrospectiveId)))
-            .thenReturn(jpaQuery);
-        when(jpaQuery.fetch()).thenReturn(List.of(response));
+        when(sectionRepository.getSections(retrospectiveId)).thenReturn(List.of(response));
 
         //when
         GetSectionsRequestDto request = new GetSectionsRequestDto();

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -31,8 +31,6 @@ import aws.retrospective.repository.SectionRepository;
 import aws.retrospective.repository.TeamRepository;
 import aws.retrospective.repository.TemplateSectionRepository;
 import aws.retrospective.repository.UserRepository;
-import com.querydsl.jpa.impl.JPAQuery;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -61,10 +59,6 @@ class SectionServiceTest {
     LikesRepository likesRepository;
     @Mock
     TeamRepository teamRepository;
-    @Mock
-    JPAQueryFactory queryFactory;
-    @Mock
-    JPAQuery jpaQuery;
     @InjectMocks
     SectionService sectionService;
 

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -1,5 +1,9 @@
 package aws.retrospective.service;
 
+import static aws.retrospective.entity.QRetrospective.*;
+import static aws.retrospective.entity.QSection.*;
+import static aws.retrospective.entity.QTemplateSection.*;
+import static aws.retrospective.entity.QUser.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
@@ -296,43 +300,43 @@ class SectionServiceTest {
     void getSectionsTest() {
         //given
         Long teamId = 1L;
-        Team team = createTeam();
-        ReflectionTestUtils.setField(team, "id", teamId);
-        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+        Team createdTeam = createTeam();
+        ReflectionTestUtils.setField(createdTeam, "id", teamId);
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(createdTeam));
 
-        RetrospectiveTemplate template = createTemplate();
-        User user = createUser();
+        RetrospectiveTemplate createdTemplate = createTemplate();
+        User createdUser = createUser();
 
         Long retrospectiveId = 1L;
-        Retrospective retrospective = createRetrospective(template, user, team);
-        ReflectionTestUtils.setField(retrospective, "id", retrospectiveId);
-        when(retrospectiveRepository.findById(retrospectiveId)).thenReturn(Optional.of(retrospective));
+        Retrospective createdRetrospective = createRetrospective(createdTemplate, createdUser, createdTeam);
+        ReflectionTestUtils.setField(createdRetrospective, "id", retrospectiveId);
+        when(retrospectiveRepository.findById(retrospectiveId)).thenReturn(Optional.of(createdRetrospective));
 
-        TemplateSection templateSection = createTemplateSection(template);
+        TemplateSection createdTemplateSection = createTemplateSection(createdTemplate);
 
         Long sectionId = 1L;
-        Section section = createSection(user, templateSection, retrospective);
-        ReflectionTestUtils.setField(section, "id", sectionId);
+        Section createdSection = createSection(createdUser, createdTemplateSection, createdRetrospective);
+        ReflectionTestUtils.setField(createdSection, "id", sectionId);
 
         GetSectionsResponseDto response = new GetSectionsResponseDto(
-            sectionId, user.getUsername(), section.getContent(), section.getLikeCnt(),
-            templateSection.getSectionName(), section.getCreatedDate()
+            sectionId, createdUser.getUsername(), createdSection.getContent(), createdSection.getLikeCnt(),
+            createdTemplateSection.getSectionName(), createdSection.getCreatedDate()
         );
 
         when(queryFactory.select(
-            new QGetSectionsResponseDto(QSection.section.id, QUser.user.username,
-                QSection.section.content,
-                QSection.section.likeCnt, QTemplateSection.templateSection.sectionName,
-                QSection.section.createdDate)))
+            new QGetSectionsResponseDto(section.id, user.username,
+                section.content,
+                section.likeCnt, templateSection.sectionName,
+                section.createdDate)))
             .thenReturn(jpaQuery);
-        when(jpaQuery.from(QSection.section)).thenReturn(jpaQuery);
-        when(jpaQuery.join(QSection.section.retrospective, QRetrospective.retrospective))
+        when(jpaQuery.from(section)).thenReturn(jpaQuery);
+        when(jpaQuery.join(section.retrospective, retrospective))
             .thenReturn(jpaQuery);
-        when(jpaQuery.join(QSection.section.user, QUser.user))
+        when(jpaQuery.join(section.user, user))
             .thenReturn(jpaQuery);
-        when(jpaQuery.join(QSection.section.templateSection, QTemplateSection.templateSection))
+        when(jpaQuery.join(section.templateSection, templateSection))
             .thenReturn(jpaQuery);
-        when(jpaQuery.where(QRetrospective.retrospective.id.eq(retrospectiveId)))
+        when(jpaQuery.where(retrospective.id.eq(retrospectiveId)))
             .thenReturn(jpaQuery);
         when(jpaQuery.fetch()).thenReturn(List.of(response));
 
@@ -345,12 +349,12 @@ class SectionServiceTest {
         //then
         assertThat(results.size()).isEqualTo(1);
         GetSectionsResponseDto result = results.get(0);
-        assertThat(result.getSectionName()).isEqualTo(templateSection.getSectionName());
-        assertThat(result.getSectionId()).isEqualTo(section.getId());
-        assertThat(result.getCreatedDate()).isEqualTo(section.getCreatedDate());
-        assertThat(result.getContent()).isEqualTo(section.getContent());
-        assertThat(result.getUsername()).isEqualTo(user.getUsername());
-        assertThat(result.getLikeCnt()).isEqualTo(section.getLikeCnt());
+        assertThat(result.getSectionName()).isEqualTo(createdTemplateSection.getSectionName());
+        assertThat(result.getSectionId()).isEqualTo(createdSection.getId());
+        assertThat(result.getCreatedDate()).isEqualTo(createdSection.getCreatedDate());
+        assertThat(result.getContent()).isEqualTo(createdSection.getContent());
+        assertThat(result.getUsername()).isEqualTo(createdUser.getUsername());
+        assertThat(result.getLikeCnt()).isEqualTo(createdSection.getLikeCnt());
 
     }
 


### PR DESCRIPTION
## 개요
- #84 

## 변경 사항

- 회고보드에 등록된 Section 전체 조회
- validation 검증 실패 시 클라이언트로 기본 메시지 전달

## 테스트

- [x] 단위테스트
- [x] 통합테스트

## 배포 계획

- Section의 댓글 기능이 구현되면 response 응답 데이터에 추가한다.