### PR TITLE
feat: 회고 카드 조회 시에 댓글을 조회할 수 있다

### DIFF
--- a/src/main/java/aws/retrospective/controller/SectionController.java
+++ b/src/main/java/aws/retrospective/controller/SectionController.java
@@ -93,7 +93,7 @@ public class SectionController {
     @GetMapping
     public CommonApiResponse<List<GetSectionsResponseDto>> getSections(@RequestBody @Valid GetSectionsRequestDto request) {
         List<GetSectionsResponseDto> response = sectionService.getSections(request);
-          return CommonApiResponse.successResponse(HttpStatus.OK, response);
+        return CommonApiResponse.successResponse(HttpStatus.OK, response);
     }
 
     /**

--- a/src/main/java/aws/retrospective/dto/GetCommentDto.java
+++ b/src/main/java/aws/retrospective/dto/GetCommentDto.java
@@ -1,0 +1,19 @@
+package aws.retrospective.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetCommentDto {
+
+    @Schema(description = "댓글 id", example = "1")
+    private Long commentId;
+    @Schema(description = "댓글 내용", example = "매우 공감됩니다!")
+    private String content;
+    @Schema(description = "댓글 작성자", example = "hope")
+    private String username;
+}

--- a/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
@@ -3,6 +3,8 @@ package aws.retrospective.dto;
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 
 @Getter
@@ -26,6 +28,8 @@ public class GetSectionsResponseDto {
     @Schema(description = "회고 카드 등록일", example = "2021-07-01T00:00:00")
     private LocalDateTime createdDate;
 
+    private List<GetCommentDto> comments = new ArrayList<>();
+
     @QueryProjection
     public GetSectionsResponseDto(Long sectionId, String username, String content, long likeCnt,
         String sectionName, LocalDateTime createdDate) {
@@ -35,5 +39,16 @@ public class GetSectionsResponseDto {
         this.likeCnt = likeCnt;
         this.sectionName = sectionName;
         this.createdDate = createdDate;
+    }
+
+    public GetSectionsResponseDto(Long sectionId, String username, String content, long likeCnt,
+        String sectionName, LocalDateTime createdDate, List<GetCommentDto> comments) {
+        this.sectionId = sectionId;
+        this.username = username;
+        this.content = content;
+        this.likeCnt = likeCnt;
+        this.sectionName = sectionName;
+        this.createdDate = createdDate;
+        this.comments = comments;
     }
 }

--- a/src/main/java/aws/retrospective/entity/Section.java
+++ b/src/main/java/aws/retrospective/entity/Section.java
@@ -45,6 +45,8 @@ public class Section extends BaseEntity {
     @OneToMany(mappedBy = "section", cascade = CascadeType.REMOVE)
     private List<Likes> likes = new ArrayList<>();
 
+    @OneToMany(mappedBy = "section", cascade = CascadeType.REMOVE)
+    private List<Comment> comments = new ArrayList<>();
 
     @Builder
     public Section(String content, long likeCnt, Retrospective retrospective, User user,

--- a/src/main/java/aws/retrospective/repository/SectionRepository.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepository.java
@@ -1,15 +1,17 @@
 package aws.retrospective.repository;
 
-import aws.retrospective.dto.GetSectionsResponseDto;
-import aws.retrospective.entity.Section;
-import java.util.List;
 import aws.retrospective.entity.Retrospective;
 import aws.retrospective.entity.Section;
 import aws.retrospective.entity.TemplateSection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SectionRepository extends JpaRepository<Section, Long>, SectionRepositoryCustom {
 
     int countByRetrospectiveAndTemplateSection(Retrospective retrospective, TemplateSection templateSection);
+
+    @Query("select s from Section s join fetch s.retrospective sr join fetch s.comments c where sr.id = :retrospectiveId")
+    List<Section> getSectionsWithComments(@Param("retrospectiveId") Long retrospectiveId);
 }

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -16,6 +16,7 @@ import aws.retrospective.dto.GetSectionsRequestDto;
 import aws.retrospective.dto.GetSectionsResponseDto;
 import aws.retrospective.dto.IncreaseSectionLikesRequestDto;
 import aws.retrospective.dto.IncreaseSectionLikesResponseDto;
+import aws.retrospective.entity.Comment;
 import aws.retrospective.entity.Likes;
 import aws.retrospective.entity.ProjectStatus;
 import aws.retrospective.entity.Retrospective;
@@ -304,12 +305,24 @@ class SectionServiceTest {
         Section createdSection = createSection(createdUser, createdTemplateSection, createdRetrospective);
         ReflectionTestUtils.setField(createdSection, "id", sectionId);
 
-        GetSectionsResponseDto response = new GetSectionsResponseDto(
-            sectionId, createdUser.getUsername(), createdSection.getContent(), createdSection.getLikeCnt(),
-            createdTemplateSection.getSectionName(), createdSection.getCreatedDate()
-        );
+        Long commentId1 = 1L;
+        Comment comment1 = Comment.builder()
+            .section(createdSection)
+            .content("content1")
+            .user(createdUser)
+            .build();
+        ReflectionTestUtils.setField(comment1, "id", commentId1);
+        Long commentId2 = 2L;
+        Comment comment2 = Comment.builder()
+            .section(createdSection)
+            .content("content2")
+            .user(createdUser)
+            .build();
+        ReflectionTestUtils.setField(comment2, "id", commentId2);
+        createdSection.getComments().add(comment1);
+        createdSection.getComments().add(comment2);
 
-        when(sectionRepository.getSections(retrospectiveId)).thenReturn(List.of(response));
+        when(sectionRepository.getSectionsWithComments(retrospectiveId)).thenReturn(List.of(createdSection));
 
         //when
         GetSectionsRequestDto request = new GetSectionsRequestDto();
@@ -326,6 +339,10 @@ class SectionServiceTest {
         assertThat(result.getContent()).isEqualTo(createdSection.getContent());
         assertThat(result.getUsername()).isEqualTo(createdUser.getUsername());
         assertThat(result.getLikeCnt()).isEqualTo(createdSection.getLikeCnt());
+        assertThat(result.getComments().size()).isEqualTo(2);
+        assertThat(result.getComments().get(0).getContent()).isEqualTo(comment1.getContent());
+        assertThat(result.getComments().get(1).getContent()).isEqualTo(comment2.getContent());
+
 
     }
 


### PR DESCRIPTION
## 개요
- #106 

## 변경 사항

- 회고 카드에서 댓글을 조회할 수 있다.

## 테스트

- [x] 로컬 테스트
- [x] 단위 테스트

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!