### PR TITLE
Feat/#117 add template section

### DIFF
--- a/src/main/java/aws/retrospective/controller/RetrospectiveTemplateController.java
+++ b/src/main/java/aws/retrospective/controller/RetrospectiveTemplateController.java
@@ -2,6 +2,7 @@ package aws.retrospective.controller;
 
 
 import aws.retrospective.common.CommonApiResponse;
+import aws.retrospective.dto.GetTemplateSectionsDto;
 import aws.retrospective.dto.RetrospectiveTemplateResponseDto;
 import aws.retrospective.service.RetrospectiveTemplateService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +11,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,6 +27,15 @@ public class RetrospectiveTemplateController {
     @GetMapping()
     public CommonApiResponse<List<RetrospectiveTemplateResponseDto>> getRetrospectiveTemplates() {
         List<RetrospectiveTemplateResponseDto> response = retrospectiveTemplateService.getRetrospectiveTemplates();
+
+        return CommonApiResponse.successResponse(HttpStatus.OK, response);
+    }
+
+    @GetMapping("/{templateId}/template-sections")
+    public CommonApiResponse<List<GetTemplateSectionsDto>> getTemplateSections(
+        @PathVariable Long templateId) {
+        List<GetTemplateSectionsDto> response = retrospectiveTemplateService.getTemplateSections(
+            templateId);
 
         return CommonApiResponse.successResponse(HttpStatus.OK, response);
     }

--- a/src/main/java/aws/retrospective/dto/GetTemplateSectionsDto.java
+++ b/src/main/java/aws/retrospective/dto/GetTemplateSectionsDto.java
@@ -1,0 +1,15 @@
+package aws.retrospective.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetTemplateSectionsDto {
+
+    private Long id;
+    private String name;
+    private Long templateId;
+    private int sequence;
+
+}

--- a/src/main/java/aws/retrospective/repository/TemplateSectionRepository.java
+++ b/src/main/java/aws/retrospective/repository/TemplateSectionRepository.java
@@ -1,8 +1,10 @@
 package aws.retrospective.repository;
 
 import aws.retrospective.entity.TemplateSection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TemplateSectionRepository extends JpaRepository<TemplateSection, Long> {
 
+    List<TemplateSection> findByTemplateId(Long templateId);
 }

--- a/src/main/java/aws/retrospective/service/RetrospectiveTemplateService.java
+++ b/src/main/java/aws/retrospective/service/RetrospectiveTemplateService.java
@@ -22,15 +22,11 @@ public class RetrospectiveTemplateService {
 
     @Transactional(readOnly = true)
     public List<RetrospectiveTemplateResponseDto> getRetrospectiveTemplates() {
-        List<RetrospectiveTemplate> templates = retrospectiveTemplateRepository
-            .findAll();
+        List<RetrospectiveTemplate> templates = retrospectiveTemplateRepository.findAll();
 
-        return templates.stream()
-            .map(template -> RetrospectiveTemplateResponseDto.builder()
-                .id(template.getId())
-                .name(template.getName())
-                .build())
-            .collect(Collectors.toList());
+        return templates.stream().map(
+            template -> RetrospectiveTemplateResponseDto.builder().id(template.getId())
+                .name(template.getName()).build()).collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
@@ -38,14 +34,10 @@ public class RetrospectiveTemplateService {
         List<TemplateSection> templateSections = templateSectionRepository.findByTemplateId(
             templateId);
 
-        return templateSections.stream()
-            .map(section -> GetTemplateSectionsDto.builder()
-                .id(section.getId())
-                .name(section.getSectionName())
-                .sequence(section.getSequence())
-                .templateId(section.getTemplate().getId())
-                .build())
-            .collect(Collectors.toList());
+        return templateSections.stream().map(
+            section -> GetTemplateSectionsDto.builder().id(section.getId())
+                .name(section.getSectionName()).sequence(section.getSequence())
+                .templateId(section.getTemplate().getId()).build()).collect(Collectors.toList());
 
     }
 

--- a/src/main/java/aws/retrospective/service/RetrospectiveTemplateService.java
+++ b/src/main/java/aws/retrospective/service/RetrospectiveTemplateService.java
@@ -1,20 +1,26 @@
 package aws.retrospective.service;
 
+import aws.retrospective.dto.GetTemplateSectionsDto;
 import aws.retrospective.dto.RetrospectiveTemplateResponseDto;
 import aws.retrospective.entity.RetrospectiveTemplate;
+import aws.retrospective.entity.TemplateSection;
 import aws.retrospective.repository.RetrospectiveTemplateRepository;
+import aws.retrospective.repository.TemplateSectionRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class RetrospectiveTemplateService {
 
     private final RetrospectiveTemplateRepository retrospectiveTemplateRepository;
+    private final TemplateSectionRepository templateSectionRepository;
 
 
+    @Transactional(readOnly = true)
     public List<RetrospectiveTemplateResponseDto> getRetrospectiveTemplates() {
         List<RetrospectiveTemplate> templates = retrospectiveTemplateRepository
             .findAll();
@@ -26,5 +32,22 @@ public class RetrospectiveTemplateService {
                 .build())
             .collect(Collectors.toList());
     }
+
+    @Transactional(readOnly = true)
+    public List<GetTemplateSectionsDto> getTemplateSections(Long templateId) {
+        List<TemplateSection> templateSections = templateSectionRepository.findByTemplateId(
+            templateId);
+
+        return templateSections.stream()
+            .map(section -> GetTemplateSectionsDto.builder()
+                .id(section.getId())
+                .name(section.getSectionName())
+                .sequence(section.getSequence())
+                .templateId(section.getTemplate().getId())
+                .build())
+            .collect(Collectors.toList());
+
+    }
+
 
 }

--- a/src/test/java/aws/retrospective/service/RetrospectiveTemplateServiceTest.java
+++ b/src/test/java/aws/retrospective/service/RetrospectiveTemplateServiceTest.java
@@ -2,11 +2,17 @@ package aws.retrospective.service;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
+import aws.retrospective.dto.GetTemplateSectionsDto;
 import aws.retrospective.dto.RetrospectiveTemplateResponseDto;
 import aws.retrospective.entity.RetrospectiveTemplate;
+import aws.retrospective.entity.TemplateSection;
 import aws.retrospective.repository.RetrospectiveTemplateRepository;
+import aws.retrospective.repository.TemplateSectionRepository;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.BDDMockito;
@@ -21,6 +27,9 @@ public class RetrospectiveTemplateServiceTest {
 
     @Mock
     private RetrospectiveTemplateRepository retrospectiveTemplateRepository;
+
+    @Mock
+    private TemplateSectionRepository templateSectionRepository;
 
 
     @InjectMocks
@@ -50,6 +59,38 @@ public class RetrospectiveTemplateServiceTest {
         assertThat(retrospectiveTemplates.get(1).getId()).isEqualTo(2L);
         assertThat(retrospectiveTemplates.get(1).getName()).isEqualTo("Template Name 2");
 
+
+    }
+
+    @Test
+    void getTemplateSections() {
+        // given
+        Long templateId = 1L;
+        RetrospectiveTemplate template = new RetrospectiveTemplate("Template Name");
+        ReflectionTestUtils.setField(template, "id", templateId);
+
+        List<TemplateSection> templateSections = IntStream.range(0, 3).mapToObj(i ->
+            TemplateSection.builder()
+                .template(template)
+                .sectionName("Section " + i)
+                .sequence(i)
+                .build()
+        ).collect(Collectors.toList());
+
+        given(templateSectionRepository.findByTemplateId(templateId)).willReturn(templateSections);
+
+        // when
+        List<GetTemplateSectionsDto> result = retrospectiveTemplateService.getTemplateSections(
+            templateId);
+
+        // then
+        assertThat(result).hasSize(3);
+        IntStream.range(0, 3).forEach(i -> {
+            assertThat(result.get(i).getId()).isNull();
+            assertThat(result.get(i).getName()).isEqualTo("Section " + i);
+            assertThat(result.get(i).getSequence()).isEqualTo(i);
+            assertThat(result.get(i).getTemplateId()).isEqualTo(templateId);
+        });
 
     }
 


### PR DESCRIPTION
## 개요
#117 
## 변경 사항

- 템플릿 id별로 속하는 섹션 리스트 조회 API 추가

## 테스트

- [x] 로컬 테스트
- [x] 유닛 테스트
![image](https://github.com/donga-it-club/past-foward-backend/assets/90817465/972a1d9e-9dfb-484b-b332-f47baa8dcc54)


## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!