### PR TITLE
fix: 응답 데이터 수정

### DIFF
--- a/src/main/java/aws/retrospective/controller/SectionController.java
+++ b/src/main/java/aws/retrospective/controller/SectionController.java
@@ -7,8 +7,6 @@ import aws.retrospective.dto.CreateSectionResponseDto;
 import aws.retrospective.dto.DeleteSectionRequestDto;
 import aws.retrospective.dto.EditSectionRequestDto;
 import aws.retrospective.dto.EditSectionResponseDto;
-import aws.retrospective.dto.FindSectionCountRequestDto;
-import aws.retrospective.dto.FindSectionCountResponseDto;
 import aws.retrospective.dto.GetSectionsRequestDto;
 import aws.retrospective.dto.GetSectionsResponseDto;
 import aws.retrospective.dto.IncreaseSectionLikesRequestDto;
@@ -95,20 +93,6 @@ public class SectionController {
     @GetMapping
     public CommonApiResponse<List<GetSectionsResponseDto>> getSections(@RequestBody @Valid GetSectionsRequestDto request) {
         List<GetSectionsResponseDto> response = sectionService.getSections(request);
-        return CommonApiResponse.successResponse(HttpStatus.OK, response);
-    }
-
-    /**
-     * 회고 카드 개수 조회
-     * ex. Keep 섹션이 등록된 회고 카드 개수 조회
-     */
-    @Operation(summary = "섹션에 등록된 회고 카드 개수 조회", description = "섹션에 등록된 카드 개수를 조회하는 API")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200")
-    })
-    @GetMapping("/counts")
-    public CommonApiResponse<FindSectionCountResponseDto> getSectionCounts(@RequestBody @Valid FindSectionCountRequestDto request) {
-        FindSectionCountResponseDto response = sectionService.getSectionCounts(request);
         return CommonApiResponse.successResponse(HttpStatus.OK, response);
     }
 

--- a/src/main/java/aws/retrospective/repository/SectionRepository.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepository.java
@@ -12,6 +12,6 @@ public interface SectionRepository extends JpaRepository<Section, Long>, Section
 
     int countByRetrospectiveAndTemplateSection(Retrospective retrospective, TemplateSection templateSection);
 
-    @Query("select s from Section s join fetch s.retrospective sr join fetch s.comments c where sr.id = :retrospectiveId")
+    @Query("select s from Section s join fetch s.retrospective sr where sr.id = :retrospectiveId")
     List<Section> getSectionsWithComments(@Param("retrospectiveId") Long retrospectiveId);
 }

--- a/src/main/java/aws/retrospective/service/SectionService.java
+++ b/src/main/java/aws/retrospective/service/SectionService.java
@@ -34,11 +34,13 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SectionService {
 
     private final SectionRepository sectionRepository;


### PR DESCRIPTION
## 개요
- #142 

## 변경 사항

- repository 수정
**DB에서는 n건 조회 -> JPA에서는 1건 조회가 되는 문제가 있었습니다.** DB에서 조회된 식별자가 동일해서 JPA에서는 1건으로 가져오는 것 같은데 이에 대해서 좀 더 알아보겠습니다.
## 테스트

- [x] API 호출

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!