### PR TITLE
fix: action items 삭제 시에 fk 문제 해결

### DIFF
--- a/src/main/java/aws/retrospective/repository/ActionItemRepository.java
+++ b/src/main/java/aws/retrospective/repository/ActionItemRepository.java
@@ -1,8 +1,10 @@
 package aws.retrospective.repository;
 
 import aws.retrospective.entity.ActionItem;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ActionItemRepository extends JpaRepository<ActionItem, Long> {
 
+    void deleteBySectionId(Long sectionId);
 }

--- a/src/main/java/aws/retrospective/service/SectionService.java
+++ b/src/main/java/aws/retrospective/service/SectionService.java
@@ -156,6 +156,8 @@ public class SectionService {
             throw new ForbiddenAccessException("작성자만 회고 카드를 삭제할 수 있습니다.");
         }
 
+        actionItemRepository.deleteBySectionId(findSection.getId());
+
         sectionRepository.delete(findSection);
     }
 


### PR DESCRIPTION
## 개요
- #184 

## 변경 사항

- Action Items에 업무 담장자를 지정한 Section 삭제 시에 외래키 문제가 발생하여 이를 해결

## 테스트

- [ ] 어떻게 이 변경 사항을 테스트했는지
- [ ] 어떤 환경에서 테스트가 이루어졌는지 (예: 로컬 개발 환경, 스테이징 환경)

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!