### PR TITLE
feat: 댓글 및 좋아요 발생시에 알림을 조회할 수 있다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: 17
           distribution: 'zulu'
 
-      - name: Setup MySQL
+      - name: Setup MySQL And Redis
         run: docker-compose up -d
 
       - name: Grant execute permission for gradlew
@@ -37,6 +37,8 @@ jobs:
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ISSUER_URI: ${{ secrets.ISSUER_URI }}
+          SPRING_REDIS_HOST: ${{ secrets.SPRING_REDIS_HOST }}
+          SPRING_REDIS_PORT: ${{ secrets.SPRING_REDIS_PORT }}
 
 
       - name: Cache Gradle packages

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.security:spring-security-oauth2-jose'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.9.0'
+
+    // Spring Data Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,15 @@ services:
     ports:
       - "3306:3306"
 
+  redis:
+    restart: always
+    image: redis:alpine
+    container_name: past-forward-redis
+    command: redis-server --port 6379
+    hostname: redis
+    ports:
+      - "6380:6379"
+
 volumes:
   data:
 

--- a/src/main/java/aws/retrospective/common/CommonApiResponse.java
+++ b/src/main/java/aws/retrospective/common/CommonApiResponse.java
@@ -26,6 +26,14 @@ public class CommonApiResponse<T> {
             .build();
     }
 
+    public static <T> CommonApiResponse<T> successResponse(HttpStatus status) {
+        return CommonApiResponse.<T>builder()
+            .code(status.value())
+            .message(null)
+            .data(null)
+            .build();
+    }
+
     public static <T> CommonApiResponse<T> errorResponse(HttpStatus status, String message) {
         return CommonApiResponse.<T>builder()
             .code(status.value())

--- a/src/main/java/aws/retrospective/config/RedisConfig.java
+++ b/src/main/java/aws/retrospective/config/RedisConfig.java
@@ -1,0 +1,24 @@
+package aws.retrospective.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+@EnableJpaRepositories(basePackages = "aws.retrospective.repository")
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/src/main/java/aws/retrospective/controller/MailController.java
+++ b/src/main/java/aws/retrospective/controller/MailController.java
@@ -34,6 +34,6 @@ public class MailController {
     })
     public CommonApiResponse<?> sendMail(@Valid @RequestBody SendMailRequestDto request) {
         mailService.sendMail(request);
-        return CommonApiResponse.successResponse(HttpStatus.OK, null);
+        return CommonApiResponse.successResponse(HttpStatus.OK);
     }
 }

--- a/src/main/java/aws/retrospective/controller/NotificationController.java
+++ b/src/main/java/aws/retrospective/controller/NotificationController.java
@@ -1,0 +1,40 @@
+package aws.retrospective.controller;
+
+import aws.retrospective.common.CommonApiResponse;
+import aws.retrospective.dto.GetNotificationResponseDto;
+import aws.retrospective.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @Operation(summary = "알림 조회", description = "알림 조회 API")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200")})
+    @GetMapping()
+    public CommonApiResponse<List<GetNotificationResponseDto>> getNewNotifications() {
+        List<GetNotificationResponseDto> notifications = notificationService.getNotifications();
+        return CommonApiResponse.successResponse(HttpStatus.OK, notifications);
+    }
+
+    @Operation(summary = "알림 읽기", description = "알림 읽음 처리 API")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200")})
+    @PostMapping("/{notificationId}")
+    public CommonApiResponse<String> readNotification(@PathVariable Long notificationId) {
+        notificationService.readNotification(notificationId);
+        return CommonApiResponse.successResponse(HttpStatus.OK, null);
+    }
+}

--- a/src/main/java/aws/retrospective/controller/NotificationController.java
+++ b/src/main/java/aws/retrospective/controller/NotificationController.java
@@ -35,6 +35,6 @@ public class NotificationController {
     @PostMapping("/{notificationId}")
     public CommonApiResponse<String> readNotification(@PathVariable Long notificationId) {
         notificationService.readNotification(notificationId);
-        return CommonApiResponse.successResponse(HttpStatus.OK, null);
+        return CommonApiResponse.successResponse(HttpStatus.OK);
     }
 }

--- a/src/main/java/aws/retrospective/controller/SectionController.java
+++ b/src/main/java/aws/retrospective/controller/SectionController.java
@@ -87,7 +87,7 @@ public class SectionController {
     public CommonApiResponse<Void> deleteSection(@CurrentUser User user,
         @PathVariable("sectionId") Long sectionId) {
         sectionService.deleteSection(sectionId, user);
-        return CommonApiResponse.successResponse(HttpStatus.NO_CONTENT, null);
+        return CommonApiResponse.successResponse(HttpStatus.NO_CONTENT);
     }
 
     // 회고 카드 전체 조회
@@ -107,7 +107,7 @@ public class SectionController {
     public CommonApiResponse<Void> assignUser(@CurrentUser User user,
         @RequestBody @Valid AssignUserRequestDto request) {
         sectionService.assignUserToActionItem(request);
-        return CommonApiResponse.successResponse(HttpStatus.NO_CONTENT, null);
+        return CommonApiResponse.successResponse(HttpStatus.NO_CONTENT);
     }
 
     @Operation(summary = "회고 카드 내 댓글 전체 조회", responses = {

--- a/src/main/java/aws/retrospective/dto/GetNotificationResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetNotificationResponseDto.java
@@ -16,9 +16,9 @@ public class GetNotificationResponseDto {
     @Schema(description = "회고 제목", example = "중간 회고")
     private String retrospectiveTitle;
     @Schema(description = "알림을 받는 사용자 ID", example = "1")
-    private Long toUserId;
+    private Long receiverId;
     @Schema(description = "알림을 발생시킨 사용자 이름", example = "test")
-    private String fromUsername;
+    private String senderName;
     @Schema(description = "이벤트를 발생시킨 사용자 프로필 이미지", example = "4728e325-6215-40ba-abd8-7bf26bcd9029")
     private String thumbnail;
     @Schema(description = "알림 타입", example = "COMMENT")
@@ -27,14 +27,14 @@ public class GetNotificationResponseDto {
     private LocalDateTime dateTime;
 
     private GetNotificationResponseDto(Long notificationId, Long sectionId,
-        String retrospectiveTitle, Long toUserId,
-        String fromUsername, String thumbnail, NotificationType notificationType,
+        String retrospectiveTitle, Long receiverId,
+        String senderName, String thumbnail, NotificationType notificationType,
         LocalDateTime dateTime) {
         this.notificationId = notificationId;
         this.sectionId = sectionId;
         this.retrospectiveTitle = retrospectiveTitle;
-        this.toUserId = toUserId;
-        this.fromUsername = fromUsername;
+        this.receiverId = receiverId;
+        this.senderName = senderName;
         this.thumbnail = thumbnail;
         this.notificationType = notificationType;
         this.dateTime = dateTime;
@@ -43,8 +43,8 @@ public class GetNotificationResponseDto {
     public static GetNotificationResponseDto of(Notification notification) {
         return new GetNotificationResponseDto(notification.getId(),
             notification.getSection().getId(),
-            notification.getRetrospective().getTitle(), notification.getToUser().getId(),
-            notification.getFromUser().getUsername(), notification.getFromUser().getThumbnail(),
+            notification.getRetrospective().getTitle(), notification.getSender().getId(),
+            notification.getReceiver().getUsername(), notification.getReceiver().getThumbnail(),
             notification.getNotificationType(), notification.getCreatedDate());
     }
 }

--- a/src/main/java/aws/retrospective/dto/GetNotificationResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetNotificationResponseDto.java
@@ -1,0 +1,50 @@
+package aws.retrospective.dto;
+
+import aws.retrospective.entity.Notification;
+import aws.retrospective.entity.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class GetNotificationResponseDto {
+
+    @Schema(description = "알림 ID", example = "1")
+    private Long notificationId;
+    @Schema(description = "이벤트가 발생한 회고보드 ID", example = "1")
+    private Long sectionId;
+    @Schema(description = "회고 제목", example = "중간 회고")
+    private String retrospectiveTitle;
+    @Schema(description = "알림을 받는 사용자 ID", example = "1")
+    private Long toUserId;
+    @Schema(description = "알림을 발생시킨 사용자 이름", example = "test")
+    private String fromUsername;
+    @Schema(description = "이벤트를 발생시킨 사용자 프로필 이미지", example = "4728e325-6215-40ba-abd8-7bf26bcd9029")
+    private String thumbnail;
+    @Schema(description = "알림 타입", example = "COMMENT")
+    private NotificationType notificationType;
+    @Schema(description = "알림 발생 시간", example = "2021-07-01T00:00:00")
+    private LocalDateTime dateTime;
+
+    private GetNotificationResponseDto(Long notificationId, Long sectionId,
+        String retrospectiveTitle, Long toUserId,
+        String fromUsername, String thumbnail, NotificationType notificationType,
+        LocalDateTime dateTime) {
+        this.notificationId = notificationId;
+        this.sectionId = sectionId;
+        this.retrospectiveTitle = retrospectiveTitle;
+        this.toUserId = toUserId;
+        this.fromUsername = fromUsername;
+        this.thumbnail = thumbnail;
+        this.notificationType = notificationType;
+        this.dateTime = dateTime;
+    }
+
+    public static GetNotificationResponseDto createNotificationDto(Notification notification) {
+        return new GetNotificationResponseDto(notification.getId(),
+            notification.getSection().getId(),
+            notification.getRetrospective().getTitle(), notification.getToUser().getId(),
+            notification.getFromUser().getUsername(), notification.getFromUser().getThumbnail(),
+            notification.getNotificationType(), notification.getCreatedDate());
+    }
+}

--- a/src/main/java/aws/retrospective/dto/GetNotificationResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetNotificationResponseDto.java
@@ -40,7 +40,7 @@ public class GetNotificationResponseDto {
         this.dateTime = dateTime;
     }
 
-    public static GetNotificationResponseDto createNotificationDto(Notification notification) {
+    public static GetNotificationResponseDto of(Notification notification) {
         return new GetNotificationResponseDto(notification.getId(),
             notification.getSection().getId(),
             notification.getRetrospective().getTitle(), notification.getToUser().getId(),

--- a/src/main/java/aws/retrospective/entity/Notification.java
+++ b/src/main/java/aws/retrospective/entity/Notification.java
@@ -67,7 +67,7 @@ public class Notification extends BaseEntity {
         this.notificationType = notificationType;
     }
 
-    public static Notification createNotification(Section section, Retrospective retrospective,
+    public static Notification of(Section section, Retrospective retrospective,
         User sender, User receiver, Comment comment, Likes likes,
         NotificationType notificationType) {
         return new Notification(section, retrospective, sender, receiver, comment, likes,

--- a/src/main/java/aws/retrospective/entity/Notification.java
+++ b/src/main/java/aws/retrospective/entity/Notification.java
@@ -1,0 +1,79 @@
+package aws.retrospective.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "section_id")
+    private Section section;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "retrospective_id")
+    private Retrospective retrospective;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_user_id")
+    private User fromUser; // 이벤트 발생시킨 사람
+
+    // 알림을 받는 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_user_id")
+    private User toUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "likes_id")
+    private Likes likes;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationStatus isRead; // 0: unread, 1: read
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType; // COMMENT, LIKE
+
+    private Notification(Section section, Retrospective retrospective, User fromUser, User toUser, Comment comment,
+        Likes likes, NotificationType notificationType) {
+        this.section = section;
+        this.retrospective = retrospective;
+        this.fromUser = fromUser;
+        this.toUser = toUser;
+        this.comment = comment;
+        this.likes = likes;
+        this.isRead = NotificationStatus.UNREAD;
+        this.notificationType = notificationType;
+    }
+
+    public static Notification createNotification(Section section, Retrospective retrospective,
+        User fromUser, User toUser, Comment comment, Likes likes, NotificationType notificationType) {
+        return new Notification(section, retrospective, fromUser, toUser, comment, likes,
+            notificationType);
+    }
+
+    public void readNotification() {
+        this.isRead = NotificationStatus.READ;
+    }
+}

--- a/src/main/java/aws/retrospective/entity/Notification.java
+++ b/src/main/java/aws/retrospective/entity/Notification.java
@@ -34,12 +34,11 @@ public class Notification extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "from_user_id")
-    private User fromUser; // 이벤트 발생시킨 사람
+    private User sender; // 알림을 발생시킨 사용자
 
-    // 알림을 받는 사용자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "to_user_id")
-    private User toUser;
+    private User receiver; // 알림을 받는 사용자
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
@@ -55,12 +54,13 @@ public class Notification extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private NotificationType notificationType; // COMMENT, LIKE
 
-    private Notification(Section section, Retrospective retrospective, User fromUser, User toUser, Comment comment,
+    private Notification(Section section, Retrospective retrospective, User sender, User receiver,
+        Comment comment,
         Likes likes, NotificationType notificationType) {
         this.section = section;
         this.retrospective = retrospective;
-        this.fromUser = fromUser;
-        this.toUser = toUser;
+        this.sender = sender;
+        this.receiver = receiver;
         this.comment = comment;
         this.likes = likes;
         this.isRead = NotificationStatus.UNREAD;
@@ -68,8 +68,9 @@ public class Notification extends BaseEntity {
     }
 
     public static Notification createNotification(Section section, Retrospective retrospective,
-        User fromUser, User toUser, Comment comment, Likes likes, NotificationType notificationType) {
-        return new Notification(section, retrospective, fromUser, toUser, comment, likes,
+        User sender, User receiver, Comment comment, Likes likes,
+        NotificationType notificationType) {
+        return new Notification(section, retrospective, sender, receiver, comment, likes,
             notificationType);
     }
 

--- a/src/main/java/aws/retrospective/entity/NotificationRedis.java
+++ b/src/main/java/aws/retrospective/entity/NotificationRedis.java
@@ -1,4 +1,4 @@
-package aws.retrospective.entity.redis;
+package aws.retrospective.entity;
 
 import java.time.LocalDateTime;
 import lombok.AccessLevel;

--- a/src/main/java/aws/retrospective/entity/NotificationStatus.java
+++ b/src/main/java/aws/retrospective/entity/NotificationStatus.java
@@ -1,0 +1,9 @@
+package aws.retrospective.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum NotificationStatus {
+    UNREAD,
+    READ
+}

--- a/src/main/java/aws/retrospective/entity/NotificationType.java
+++ b/src/main/java/aws/retrospective/entity/NotificationType.java
@@ -1,0 +1,9 @@
+package aws.retrospective.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum NotificationType {
+    COMMENT,
+    LIKE
+}

--- a/src/main/java/aws/retrospective/entity/redis/NotificationRedis.java
+++ b/src/main/java/aws/retrospective/entity/redis/NotificationRedis.java
@@ -18,7 +18,7 @@ public class NotificationRedis {
         this.lastNotificationTime = lastNotificationTime;
     }
 
-    public static NotificationRedis createNotification(String notification, LocalDateTime lastNotificationTime) {
+    public static NotificationRedis of(String notification, LocalDateTime lastNotificationTime) {
         return new NotificationRedis(notification, lastNotificationTime);
     }
 }

--- a/src/main/java/aws/retrospective/entity/redis/NotificationRedis.java
+++ b/src/main/java/aws/retrospective/entity/redis/NotificationRedis.java
@@ -1,22 +1,20 @@
 package aws.retrospective.entity.redis;
 
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 @Getter
 @RedisHash("Notification")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class NotificationRedis {
 
     @Id
     private String notification; // key
     private LocalDateTime lastNotificationTime; // value
-
-    private NotificationRedis(String notification, LocalDateTime lastNotificationTime) {
-        this.notification = notification;
-        this.lastNotificationTime = lastNotificationTime;
-    }
 
     public static NotificationRedis of(String notification, LocalDateTime lastNotificationTime) {
         return new NotificationRedis(notification, lastNotificationTime);

--- a/src/main/java/aws/retrospective/entity/redis/NotificationRedis.java
+++ b/src/main/java/aws/retrospective/entity/redis/NotificationRedis.java
@@ -1,0 +1,24 @@
+package aws.retrospective.entity.redis;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash("Notification")
+public class NotificationRedis {
+
+    @Id
+    private String notification; // key
+    private LocalDateTime lastNotificationTime; // value
+
+    private NotificationRedis(String notification, LocalDateTime lastNotificationTime) {
+        this.notification = notification;
+        this.lastNotificationTime = lastNotificationTime;
+    }
+
+    public static NotificationRedis createNotification(String notification, LocalDateTime lastNotificationTime) {
+        return new NotificationRedis(notification, lastNotificationTime);
+    }
+}

--- a/src/main/java/aws/retrospective/repository/NotificationRedisRepository.java
+++ b/src/main/java/aws/retrospective/repository/NotificationRedisRepository.java
@@ -1,6 +1,6 @@
 package aws.retrospective.repository;
 
-import aws.retrospective.entity.redis.NotificationRedis;
+import aws.retrospective.entity.NotificationRedis;
 import org.springframework.data.repository.CrudRepository;
 
 public interface NotificationRedisRepository extends CrudRepository<NotificationRedis, String> {

--- a/src/main/java/aws/retrospective/repository/NotificationRedisRepository.java
+++ b/src/main/java/aws/retrospective/repository/NotificationRedisRepository.java
@@ -1,0 +1,8 @@
+package aws.retrospective.repository;
+
+import aws.retrospective.entity.redis.NotificationRedis;
+import org.springframework.data.repository.CrudRepository;
+
+public interface NotificationRedisRepository extends CrudRepository<NotificationRedis, String> {
+
+}

--- a/src/main/java/aws/retrospective/repository/NotificationRepository.java
+++ b/src/main/java/aws/retrospective/repository/NotificationRepository.java
@@ -1,0 +1,18 @@
+package aws.retrospective.repository;
+
+import aws.retrospective.entity.Notification;
+import aws.retrospective.entity.NotificationStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByIsReadOrCreatedDateAfter(NotificationStatus isRead,
+        LocalDateTime createdDate);
+
+    Optional<Notification> findNotificationByCommentId(Long commentId);
+
+    Optional<Notification> findNotificationByLikesId(Long likesId);
+}

--- a/src/main/java/aws/retrospective/service/CommentService.java
+++ b/src/main/java/aws/retrospective/service/CommentService.java
@@ -120,8 +120,9 @@ public class CommentService {
     }
 
     private static Notification createNotification(User user, Section section, Comment comment) {
-        return Notification.createNotification(section,
-            section.getRetrospective(), comment.getUser(), section.getUser(), comment, null, NotificationType.COMMENT);
+        return Notification.of(section,
+            section.getRetrospective(), comment.getUser(), section.getUser(), comment, null,
+            NotificationType.COMMENT);
     }
 
 }

--- a/src/main/java/aws/retrospective/service/CommentService.java
+++ b/src/main/java/aws/retrospective/service/CommentService.java
@@ -1,16 +1,18 @@
 package aws.retrospective.service;
 
-
 import aws.retrospective.dto.CreateCommentDto;
 import aws.retrospective.dto.CreateCommentResponseDto;
 import aws.retrospective.dto.GetCommentsResponseDto;
 import aws.retrospective.dto.UpdateCommentRequestDto;
 import aws.retrospective.dto.UpdateCommentResponseDto;
 import aws.retrospective.entity.Comment;
+import aws.retrospective.entity.Notification;
+import aws.retrospective.entity.NotificationType;
 import aws.retrospective.entity.Section;
 import aws.retrospective.entity.User;
 import aws.retrospective.exception.custom.ForbiddenAccessException;
 import aws.retrospective.repository.CommentRepository;
+import aws.retrospective.repository.NotificationRepository;
 import aws.retrospective.repository.SectionRepository;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -24,6 +26,7 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final SectionRepository sectionRepository;
+    private final NotificationRepository notificationRepository;
 
 
     // 댓글 생성
@@ -31,12 +34,15 @@ public class CommentService {
     public CreateCommentResponseDto createComment(User user, CreateCommentDto request) {
 
         // 댓글이 속한 섹션 정보 가져오기
-        Section sectionId = sectionRepository.findById(request.getSectionId())
+        Section section = sectionRepository.findById(request.getSectionId())
             .orElseThrow(() -> new NoSuchElementException("Section not found with ID"));
 
         // 새 댓글 생성
-        Comment createComment = createComment(request.getCommentContent(), sectionId, user);
+        Comment createComment = createComment(request.getCommentContent(), section, user);
         commentRepository.save(createComment);
+
+        Notification notification = createNotification(user, section, createComment);
+        notificationRepository.save(notification);
 
         return new CreateCommentResponseDto(
             createComment.getId(),
@@ -84,8 +90,10 @@ public class CommentService {
             throw new ForbiddenAccessException("작성자만 댓글을 삭제할 수 있습니다.");
         }
 
-        commentRepository.delete(findComment);
+        notificationRepository.findNotificationByCommentId(commentId)
+            .ifPresent(notificationRepository::delete);
 
+        commentRepository.delete(findComment);
     }
 
     // 모든 댓글 조회
@@ -109,6 +117,11 @@ public class CommentService {
         return commentRepository.findById(commentId)
             .orElseThrow(
                 () -> new NoSuchElementException("Comment not found with ID: " + commentId));
+    }
+
+    private static Notification createNotification(User user, Section section, Comment comment) {
+        return Notification.createNotification(section,
+            section.getRetrospective(), comment.getUser(), section.getUser(), comment, null, NotificationType.COMMENT);
     }
 
 }

--- a/src/main/java/aws/retrospective/service/NotificationService.java
+++ b/src/main/java/aws/retrospective/service/NotificationService.java
@@ -3,7 +3,7 @@ package aws.retrospective.service;
 import aws.retrospective.dto.GetNotificationResponseDto;
 import aws.retrospective.entity.Notification;
 import aws.retrospective.entity.NotificationStatus;
-import aws.retrospective.entity.redis.NotificationRedis;
+import aws.retrospective.entity.NotificationRedis;
 import aws.retrospective.repository.NotificationRedisRepository;
 import aws.retrospective.repository.NotificationRepository;
 import java.time.LocalDateTime;

--- a/src/main/java/aws/retrospective/service/NotificationService.java
+++ b/src/main/java/aws/retrospective/service/NotificationService.java
@@ -44,14 +44,14 @@ public class NotificationService {
     }
 
     private static NotificationRedis createNotification() {
-        return NotificationRedis.createNotification(NOTIFICATION,
+        return NotificationRedis.of(NOTIFICATION,
             LocalDateTime.now());
     }
 
     private List<GetNotificationResponseDto> convertDto(NotificationRedis notificationRedis) {
         return notificationRepository.findByIsReadOrCreatedDateAfter(
                 NotificationStatus.UNREAD, notificationRedis.getLastNotificationTime()).stream()
-            .map(GetNotificationResponseDto::createNotificationDto)
+            .map(GetNotificationResponseDto::of)
             .toList();
     }
 

--- a/src/main/java/aws/retrospective/service/NotificationService.java
+++ b/src/main/java/aws/retrospective/service/NotificationService.java
@@ -1,0 +1,62 @@
+package aws.retrospective.service;
+
+import aws.retrospective.dto.GetNotificationResponseDto;
+import aws.retrospective.entity.Notification;
+import aws.retrospective.entity.NotificationStatus;
+import aws.retrospective.entity.redis.NotificationRedis;
+import aws.retrospective.repository.NotificationRedisRepository;
+import aws.retrospective.repository.NotificationRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationRedisRepository redisRepository;
+
+    private static final String NOTIFICATION = "notification";
+
+    @Transactional
+    public void readNotification(Long notificationId) {
+        Notification notification = getNotification(notificationId);
+        notification.readNotification();
+    }
+
+    @Transactional(readOnly = true)
+    public List<GetNotificationResponseDto> getNotifications() {
+        NotificationRedis notificationRedis = findNotification();
+
+        NotificationRedis notification = createNotification();
+        redisRepository.save(notification);
+
+        return convertDto(notificationRedis);
+    }
+
+    private NotificationRedis findNotification() {
+        return redisRepository.findById(NOTIFICATION)
+            .orElseThrow(() -> new NoSuchElementException("알림을 조회할 수 없습니다. ID: " + NOTIFICATION));
+    }
+
+    private static NotificationRedis createNotification() {
+        return NotificationRedis.createNotification(NOTIFICATION,
+            LocalDateTime.now());
+    }
+
+    private List<GetNotificationResponseDto> convertDto(NotificationRedis notificationRedis) {
+        return notificationRepository.findByIsReadOrCreatedDateAfter(
+                NotificationStatus.UNREAD, notificationRedis.getLastNotificationTime()).stream()
+            .map(GetNotificationResponseDto::createNotificationDto)
+            .toList();
+    }
+
+    private Notification getNotification(Long notificationId) {
+        return notificationRepository.findById(notificationId)
+            .orElseThrow(() -> new NoSuchElementException("알림을 조회할 수 없습니다. ID: " + notificationId));
+    }
+}

--- a/src/main/java/aws/retrospective/service/SectionService.java
+++ b/src/main/java/aws/retrospective/service/SectionService.java
@@ -15,6 +15,8 @@ import aws.retrospective.dto.IncreaseSectionLikesResponseDto;
 import aws.retrospective.entity.ActionItem;
 import aws.retrospective.entity.KudosTarget;
 import aws.retrospective.entity.Likes;
+import aws.retrospective.entity.Notification;
+import aws.retrospective.entity.NotificationType;
 import aws.retrospective.entity.Retrospective;
 import aws.retrospective.entity.Section;
 import aws.retrospective.entity.Team;
@@ -24,6 +26,7 @@ import aws.retrospective.exception.custom.ForbiddenAccessException;
 import aws.retrospective.repository.ActionItemRepository;
 import aws.retrospective.repository.KudosTargetRepository;
 import aws.retrospective.repository.LikesRepository;
+import aws.retrospective.repository.NotificationRepository;
 import aws.retrospective.repository.RetrospectiveRepository;
 import aws.retrospective.repository.SectionRepository;
 import aws.retrospective.repository.TeamRepository;
@@ -52,6 +55,7 @@ public class SectionService {
     private final ActionItemRepository actionItemRepository;
     private final UserRepository userRepository;
     private final KudosTargetRepository kudosRepository;
+    private final NotificationRepository notificationRepository;
 
     // 회고 카드 전체 조회
     @Transactional(readOnly = true)
@@ -131,8 +135,15 @@ public class SectionService {
             Likes createLikes = Likes.builder().section(findSection).user(user).build();
             likesRepository.save(createLikes);
             findSection.increaseSectionLikes();
+
+            Notification notification = Notification.createNotification(findSection,
+                findSection.getRetrospective(),
+                user, findSection.getUser(), null, createLikes, NotificationType.LIKE);
+            notificationRepository.save(notification);
         } else {
             Likes likes = findLikes.get();
+            notificationRepository.findNotificationByLikesId(likes.getId())
+                .ifPresent(notificationRepository::delete);
             likesRepository.delete(likes);
             findSection.cancelSectionLikes();
         }

--- a/src/main/java/aws/retrospective/service/SectionService.java
+++ b/src/main/java/aws/retrospective/service/SectionService.java
@@ -136,7 +136,7 @@ public class SectionService {
             likesRepository.save(createLikes);
             findSection.increaseSectionLikes();
 
-            Notification notification = Notification.createNotification(findSection,
+            Notification notification = Notification.of(findSection,
                 findSection.getRetrospective(),
                 user, findSection.getUser(), null, createLikes, NotificationType.LIKE);
             notificationRepository.save(notification);

--- a/src/main/resources-local/application-local.yml
+++ b/src/main/resources-local/application-local.yml
@@ -25,8 +25,8 @@ spring:
           issuer-uri: ${ISSUER_URI}
   data:
     redis:
-      host: 127.0.0.1
-      port: 6379
+      host: localhost
+      port: 6380
 
 aws:
   secretsmanager:

--- a/src/main/resources-prod/application-prod.yml
+++ b/src/main/resources-prod/application-prod.yml
@@ -25,6 +25,10 @@ spring:
   config:
     activate:
       on-profile: prod
+  data:
+    redis:
+      host: ${SPRING_REDIS_HOST}
+      port: ${SPRING_REDIS_PORT}
 
 aws:
   ses:

--- a/src/test/java/aws/retrospective/service/CommentServiceTest.java
+++ b/src/test/java/aws/retrospective/service/CommentServiceTest.java
@@ -15,6 +15,7 @@ import aws.retrospective.entity.Comment;
 import aws.retrospective.entity.Section;
 import aws.retrospective.entity.User;
 import aws.retrospective.repository.CommentRepository;
+import aws.retrospective.repository.NotificationRepository;
 import aws.retrospective.repository.SectionRepository;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -33,6 +34,8 @@ class CommentServiceTest {
     private SectionRepository sectionRepository;
     @Mock
     private CommentRepository commentRepository;
+    @Mock
+    private NotificationRepository notificationRepository;
     @InjectMocks
     private CommentService commentService;
 

--- a/src/test/java/aws/retrospective/service/NotificationServiceTest.java
+++ b/src/test/java/aws/retrospective/service/NotificationServiceTest.java
@@ -10,7 +10,7 @@ import aws.retrospective.entity.Retrospective;
 import aws.retrospective.entity.RetrospectiveTemplate;
 import aws.retrospective.entity.Section;
 import aws.retrospective.entity.User;
-import aws.retrospective.entity.redis.NotificationRedis;
+import aws.retrospective.entity.NotificationRedis;
 import aws.retrospective.repository.NotificationRedisRepository;
 import aws.retrospective.repository.NotificationRepository;
 import aws.retrospective.repository.RetrospectiveRepository;

--- a/src/test/java/aws/retrospective/service/NotificationServiceTest.java
+++ b/src/test/java/aws/retrospective/service/NotificationServiceTest.java
@@ -1,0 +1,199 @@
+package aws.retrospective.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import aws.retrospective.dto.CreateCommentDto;
+import aws.retrospective.dto.GetNotificationResponseDto;
+import aws.retrospective.entity.Notification;
+import aws.retrospective.entity.NotificationType;
+import aws.retrospective.entity.Retrospective;
+import aws.retrospective.entity.RetrospectiveTemplate;
+import aws.retrospective.entity.Section;
+import aws.retrospective.entity.User;
+import aws.retrospective.entity.redis.NotificationRedis;
+import aws.retrospective.repository.NotificationRedisRepository;
+import aws.retrospective.repository.NotificationRepository;
+import aws.retrospective.repository.RetrospectiveRepository;
+import aws.retrospective.repository.RetrospectiveTemplateRepository;
+import aws.retrospective.repository.SectionRepository;
+import aws.retrospective.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("local")
+class NotificationServiceTest {
+
+    @Autowired
+    NotificationService notificationService;
+    @Autowired
+    CommentService commentService;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    SectionRepository sectionRepository;
+    @Autowired
+    RetrospectiveRepository retrospectiveRepository;
+    @Autowired
+    RetrospectiveTemplateRepository templateRepository;
+    @Autowired
+    NotificationRedisRepository notificationRedisRepository;
+    @Autowired
+    SectionService sectionService;
+    @Autowired
+    NotificationRepository notificationRepository;
+
+    @AfterEach
+    public void tearDown() {
+        notificationRedisRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("회고 보드에 댓글이 작성되면 알림을 생성 및 조회할 수 있다.")
+    void createNotificationFromComment() {
+        //given
+        User user = User.builder().username("test").phone("010-1234-1234").email("test@naver.com")
+            .build();
+        User savedUser = userRepository.save(user);
+
+        RetrospectiveTemplate template = RetrospectiveTemplate.builder().name("KPT").build();
+        templateRepository.save(template);
+
+        Retrospective retrospective = Retrospective.builder().title("title").user(user)
+            .template(template).build();
+        retrospectiveRepository.save(retrospective);
+
+        Section section = Section.builder().likeCnt(0).user(user).retrospective(retrospective)
+            .build();
+        Section savedSection = sectionRepository.save(section);
+
+        CreateCommentDto request = new CreateCommentDto();
+        ReflectionTestUtils.setField(request, "sectionId", savedSection.getId());
+        ReflectionTestUtils.setField(request, "commentContent", "content");
+
+        NotificationRedis redis = NotificationRedis.createNotification("notification",
+            LocalDateTime.now());// 마지막으로 알림이 전송된 시간을 레디스에 저장
+        notificationRedisRepository.save(redis);
+
+        //when
+        commentService.createComment(savedUser, request); // 댓글 작성
+        // 레디스에 저장된 시간 이후의 알림 조회
+        List<GetNotificationResponseDto> notifications = notificationService.getNotifications();
+
+        //then
+        GetNotificationResponseDto notification = notifications.get(0);
+        assertThat(notifications.size()).isEqualTo(1);
+        assertThat(notification.getSectionId()).isEqualTo(savedSection.getId());
+        assertThat(notification.getRetrospectiveTitle()).isEqualTo(
+            retrospective.getTitle());
+        assertThat(notification.getToUserId()).isEqualTo(savedUser.getId());
+        assertThat(notification.getFromUsername()).isEqualTo(savedUser.getUsername());
+        assertThat(notification.getThumbnail()).isEqualTo(savedUser.getThumbnail());
+        assertThat(notification.getNotificationType()).isEqualTo(NotificationType.COMMENT);
+    }
+
+    @Test
+    @DisplayName("회고 보드에 좋아요 이벤트가 발생하면 알림을 생성 및 조회할 수 있다.")
+    void createNotificationFromLike() {
+        //given
+        User user = User.builder().username("test").phone("010-1234-1234").email("test@naver.com")
+            .build();
+        User savedUser = userRepository.save(user);
+
+        RetrospectiveTemplate template = RetrospectiveTemplate.builder().name("KPT").build();
+        templateRepository.save(template);
+
+        Retrospective retrospective = Retrospective.builder().title("title").user(user)
+            .template(template).build();
+        retrospectiveRepository.save(retrospective);
+
+        Section section = Section.builder().likeCnt(0).user(user).retrospective(retrospective)
+            .build();
+        Section savedSection = sectionRepository.save(section);
+
+        NotificationRedis redis = NotificationRedis.createNotification("notification",
+            LocalDateTime.now());// 마지막으로 알림이 전송된 시간을 레디스에 저장
+        notificationRedisRepository.save(redis);
+
+        //when
+        sectionService.increaseSectionLikes(savedSection.getId(), user); // 회고 보드에 좋아요 클릭
+        // 레디스에 저장된 시간 이후의 알림 조회
+        List<GetNotificationResponseDto> notifications = notificationService.getNotifications();
+
+        //then
+        GetNotificationResponseDto notification = notifications.get(0);
+        assertThat(notifications.size()).isEqualTo(1);
+        assertThat(notification.getSectionId()).isEqualTo(savedSection.getId());
+        assertThat(notification.getRetrospectiveTitle()).isEqualTo(
+            retrospective.getTitle());
+        assertThat(notification.getToUserId()).isEqualTo(savedUser.getId());
+        assertThat(notification.getFromUsername()).isEqualTo(savedUser.getUsername());
+        assertThat(notification.getThumbnail()).isEqualTo(savedUser.getThumbnail());
+        assertThat(notification.getNotificationType()).isEqualTo(NotificationType.LIKE);
+    }
+
+    @Test
+    @DisplayName("알림을 읽으면 읽음 상태로 변경된다.")
+    void readNotification() {
+        //given
+        User user = User.builder().username("test").phone("010-1234-1234").email("test@naver.com")
+            .build();
+        User savedUser = userRepository.save(user);
+
+        RetrospectiveTemplate template = RetrospectiveTemplate.builder().name("KPT").build();
+        templateRepository.save(template);
+
+        Retrospective retrospective = Retrospective.builder().title("title").user(user)
+            .template(template).build();
+        retrospectiveRepository.save(retrospective);
+
+        Section section = Section.builder().likeCnt(0).user(user).retrospective(retrospective)
+            .build();
+        Section savedSection = sectionRepository.save(section);
+
+        NotificationRedis redis = NotificationRedis.createNotification("notification",
+            LocalDateTime.now());// 마지막으로 알림이 전송된 시간을 레디스에 저장
+        notificationRedisRepository.save(redis);
+
+        CreateCommentDto request = new CreateCommentDto();
+        ReflectionTestUtils.setField(request, "sectionId", savedSection.getId());
+        ReflectionTestUtils.setField(request, "commentContent", "content");
+        commentService.createComment(savedUser, request); // 댓글 작성
+
+        sectionService.increaseSectionLikes(savedSection.getId(), user); // 회고 보드에 좋아요 클릭
+
+        //when
+        List<GetNotificationResponseDto> unreadNotifications = notificationService.getNotifications();
+        GetNotificationResponseDto unreadResponse = unreadNotifications.get(0);
+
+        Long notificationId = unreadResponse.getNotificationId();
+        Notification findNotification = notificationRepository.findById(notificationId)
+            .orElse(null);
+        findNotification.readNotification(); // 알림 읽음 처리
+
+        // 알림 읽은 후 다시 조회
+        List<GetNotificationResponseDto> readNotifications = notificationService.getNotifications();
+
+        //then
+        assertThat(unreadNotifications.size()).isEqualTo(2);
+
+        GetNotificationResponseDto notification = readNotifications.get(0);
+        assertThat(readNotifications.size()).isEqualTo(1);
+        assertThat(notification.getSectionId()).isEqualTo(savedSection.getId());
+        assertThat(notification.getRetrospectiveTitle()).isEqualTo(
+            retrospective.getTitle());
+        assertThat(notification.getToUserId()).isEqualTo(savedUser.getId());
+        assertThat(notification.getFromUsername()).isEqualTo(savedUser.getUsername());
+        assertThat(notification.getThumbnail()).isEqualTo(savedUser.getThumbnail());
+        assertThat(notification.getNotificationType()).isEqualTo(NotificationType.LIKE);
+    }
+}

--- a/src/test/java/aws/retrospective/service/NotificationServiceTest.java
+++ b/src/test/java/aws/retrospective/service/NotificationServiceTest.java
@@ -17,6 +17,7 @@ import aws.retrospective.repository.RetrospectiveRepository;
 import aws.retrospective.repository.RetrospectiveTemplateRepository;
 import aws.retrospective.repository.SectionRepository;
 import aws.retrospective.repository.UserRepository;
+import aws.retrospective.util.TestUtil;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -25,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -76,9 +76,7 @@ class NotificationServiceTest {
             .build();
         Section savedSection = sectionRepository.save(section);
 
-        CreateCommentDto request = new CreateCommentDto();
-        ReflectionTestUtils.setField(request, "sectionId", savedSection.getId());
-        ReflectionTestUtils.setField(request, "commentContent", "content");
+        CreateCommentDto request = TestUtil.createCommentDto(section.getId());
 
         NotificationRedis redis = NotificationRedis.of("notification",
             LocalDateTime.now());// 마지막으로 알림이 전송된 시간을 레디스에 저장
@@ -164,9 +162,7 @@ class NotificationServiceTest {
             LocalDateTime.now());// 마지막으로 알림이 전송된 시간을 레디스에 저장
         notificationRedisRepository.save(redis);
 
-        CreateCommentDto request = new CreateCommentDto();
-        ReflectionTestUtils.setField(request, "sectionId", savedSection.getId());
-        ReflectionTestUtils.setField(request, "commentContent", "content");
+        CreateCommentDto request = TestUtil.createCommentDto(section.getId());
         commentService.createComment(savedUser, request); // 댓글 작성
 
         sectionService.increaseSectionLikes(savedSection.getId(), user); // 회고 보드에 좋아요 클릭

--- a/src/test/java/aws/retrospective/service/NotificationServiceTest.java
+++ b/src/test/java/aws/retrospective/service/NotificationServiceTest.java
@@ -95,8 +95,8 @@ class NotificationServiceTest {
         assertThat(notification.getSectionId()).isEqualTo(savedSection.getId());
         assertThat(notification.getRetrospectiveTitle()).isEqualTo(
             retrospective.getTitle());
-        assertThat(notification.getToUserId()).isEqualTo(savedUser.getId());
-        assertThat(notification.getFromUsername()).isEqualTo(savedUser.getUsername());
+        assertThat(notification.getReceiverId()).isEqualTo(savedUser.getId());
+        assertThat(notification.getSenderName()).isEqualTo(savedUser.getUsername());
         assertThat(notification.getThumbnail()).isEqualTo(savedUser.getThumbnail());
         assertThat(notification.getNotificationType()).isEqualTo(NotificationType.COMMENT);
     }
@@ -135,8 +135,8 @@ class NotificationServiceTest {
         assertThat(notification.getSectionId()).isEqualTo(savedSection.getId());
         assertThat(notification.getRetrospectiveTitle()).isEqualTo(
             retrospective.getTitle());
-        assertThat(notification.getToUserId()).isEqualTo(savedUser.getId());
-        assertThat(notification.getFromUsername()).isEqualTo(savedUser.getUsername());
+        assertThat(notification.getReceiverId()).isEqualTo(savedUser.getId());
+        assertThat(notification.getSenderName()).isEqualTo(savedUser.getUsername());
         assertThat(notification.getThumbnail()).isEqualTo(savedUser.getThumbnail());
         assertThat(notification.getNotificationType()).isEqualTo(NotificationType.LIKE);
     }
@@ -191,8 +191,8 @@ class NotificationServiceTest {
         assertThat(notification.getSectionId()).isEqualTo(savedSection.getId());
         assertThat(notification.getRetrospectiveTitle()).isEqualTo(
             retrospective.getTitle());
-        assertThat(notification.getToUserId()).isEqualTo(savedUser.getId());
-        assertThat(notification.getFromUsername()).isEqualTo(savedUser.getUsername());
+        assertThat(notification.getReceiverId()).isEqualTo(savedUser.getId());
+        assertThat(notification.getSenderName()).isEqualTo(savedUser.getUsername());
         assertThat(notification.getThumbnail()).isEqualTo(savedUser.getThumbnail());
         assertThat(notification.getNotificationType()).isEqualTo(NotificationType.LIKE);
     }

--- a/src/test/java/aws/retrospective/service/NotificationServiceTest.java
+++ b/src/test/java/aws/retrospective/service/NotificationServiceTest.java
@@ -80,7 +80,7 @@ class NotificationServiceTest {
         ReflectionTestUtils.setField(request, "sectionId", savedSection.getId());
         ReflectionTestUtils.setField(request, "commentContent", "content");
 
-        NotificationRedis redis = NotificationRedis.createNotification("notification",
+        NotificationRedis redis = NotificationRedis.of("notification",
             LocalDateTime.now());// 마지막으로 알림이 전송된 시간을 레디스에 저장
         notificationRedisRepository.save(redis);
 
@@ -120,7 +120,7 @@ class NotificationServiceTest {
             .build();
         Section savedSection = sectionRepository.save(section);
 
-        NotificationRedis redis = NotificationRedis.createNotification("notification",
+        NotificationRedis redis = NotificationRedis.of("notification",
             LocalDateTime.now());// 마지막으로 알림이 전송된 시간을 레디스에 저장
         notificationRedisRepository.save(redis);
 
@@ -160,7 +160,7 @@ class NotificationServiceTest {
             .build();
         Section savedSection = sectionRepository.save(section);
 
-        NotificationRedis redis = NotificationRedis.createNotification("notification",
+        NotificationRedis redis = NotificationRedis.of("notification",
             LocalDateTime.now());// 마지막으로 알림이 전송된 시간을 레디스에 저장
         notificationRedisRepository.save(redis);
 

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -35,6 +35,7 @@ import aws.retrospective.exception.custom.ForbiddenAccessException;
 import aws.retrospective.repository.ActionItemRepository;
 import aws.retrospective.repository.KudosTargetRepository;
 import aws.retrospective.repository.LikesRepository;
+import aws.retrospective.repository.NotificationRepository;
 import aws.retrospective.repository.RetrospectiveRepository;
 import aws.retrospective.repository.SectionRepository;
 import aws.retrospective.repository.TeamRepository;
@@ -73,6 +74,8 @@ class SectionServiceTest {
     UserRepository userRepository;
     @Mock
     KudosTargetRepository kudosRepository;
+    @Mock
+    NotificationRepository notificationRepository;
     @InjectMocks
     SectionService sectionService;
 

--- a/src/test/java/aws/retrospective/util/TestUtil.java
+++ b/src/test/java/aws/retrospective/util/TestUtil.java
@@ -1,5 +1,6 @@
 package aws.retrospective.util;
 
+import aws.retrospective.dto.CreateCommentDto;
 import aws.retrospective.entity.Bookmark;
 import aws.retrospective.entity.ProjectStatus;
 import aws.retrospective.entity.Retrospective;
@@ -9,6 +10,7 @@ import aws.retrospective.entity.Team;
 import aws.retrospective.entity.User;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class TestUtil {
 
@@ -63,6 +65,13 @@ public class TestUtil {
             .user(user)
             .retrospective(retrospective)
             .build();
+    }
+
+    public static CreateCommentDto createCommentDto(Long sectionId) {
+        CreateCommentDto request = new CreateCommentDto();
+        ReflectionTestUtils.setField(request, "sectionId", sectionId);
+        ReflectionTestUtils.setField(request, "commentContent", "content");
+        return request;
     }
 
 }

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -10,7 +10,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -25,8 +25,8 @@ spring:
           issuer-uri: ${ISSUER_URI}
   data:
     redis:
-      host: 127.0.0.1
-      port: 6379
+      host: localhost
+      port: 6380
 
 aws:
   secretsmanager:


### PR DESCRIPTION
## 개요
- #218 

## 변경 사항

- 회고 보드에 댓글이 작성되면 알림이 발생한다
- 회고 보드에 좋아요 이벤트가 발생하면 알림이 발생한다.
- 사용자가 알림을 읽음 처리할 수 있다. 

## 테스트

- [x] 테스트 코드
- [x] API 호출

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!