### PR TITLE
fix: 2개 이상의 kudos 회고 카드에 동일한 사용자를 지정할 수 있다

### DIFF
--- a/src/main/java/aws/retrospective/entity/KudosTarget.java
+++ b/src/main/java/aws/retrospective/entity/KudosTarget.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -26,7 +27,7 @@ public class KudosTarget extends BaseEntity{
     @JoinColumn(name = "section_id")
     private Section section;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 


### PR DESCRIPTION
## 개요
- #225 

## 변경 사항

- Kudos 테이블에서 Section 필드에 unique 조건을 제거합니다(@OneToOne -> @ManyToOne)

## 테스트

- [ ] 어떻게 이 변경 사항을 테스트했는지
- [ ] 어떤 환경에서 테스트가 이루어졌는지 (예: 로컬 개발 환경, 스테이징 환경)

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!