### PR TITLE
fix: 테스트용 bootstrap 생성

### DIFF
--- a/src/test/java/aws/retrospective/RetrospectiveApplicationTests.java
+++ b/src/test/java/aws/retrospective/RetrospectiveApplicationTests.java
@@ -4,7 +4,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(classes = RetrospectiveApplicationTests.class)
-@ActiveProfiles("local")
+@ActiveProfiles("test")
 class RetrospectiveApplicationTests {
 
 

--- a/src/test/java/aws/retrospective/service/NotificationServiceTest.java
+++ b/src/test/java/aws/retrospective/service/NotificationServiceTest.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("local")
+@ActiveProfiles("test")
 class NotificationServiceTest {
 
     @Autowired

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -17,7 +17,7 @@ spring:
     open-in-view: false
   config:
     activate:
-      on-profile: local
+      on-profile: test
   security:
     oauth2:
       resourceserver:

--- a/src/test/resources/bootstrap-test.yml
+++ b/src/test/resources/bootstrap-test.yml
@@ -1,0 +1,3 @@
+aws:
+  secretsmanager:
+    enabled: off


### PR DESCRIPTION
## 개요
- #233 

## 변경 사항

- 테스트용 bootstrap.yml 생성 
Mock 테스트가 아닌 의존성을 주입 받아서 테스트하는 **NotificationServiceTest 에서 AWS Secrets Manager를 사용**하는 과정에서 문제가 있습니다.
기존 테스트용 `application-local.yml에 aws.secretsmanager.enabled = off` 가 되어 있음에도 문제가 발생하네요😂
-> 확인을 해보니 **bootstrap.yml**도 생성하여 **AWS Secrets Manager를 사용하지 않겠다는 것을 명시**해야하는 것 같습니다.
- 기존 테스트용 application-local.yml -> application-test.yml 파일명 수정

## 테스트

- [ ] 어떻게 이 변경 사항을 테스트했는지
- [ ] 어떤 환경에서 테스트가 이루어졌는지 (예: 로컬 개발 환경, 스테이징 환경)

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!