### PR TITLE
feat: 알림 전체 삭제 API 

### DIFF
--- a/src/main/java/aws/retrospective/controller/NotificationController.java
+++ b/src/main/java/aws/retrospective/controller/NotificationController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,6 +36,12 @@ public class NotificationController {
     @PostMapping("/{notificationId}")
     public CommonApiResponse<Void> readNotification(@PathVariable Long notificationId) {
         notificationService.readNotification(notificationId);
+        return CommonApiResponse.successResponse(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{userId}")
+    public CommonApiResponse<Void> deleteNotificationAll(@PathVariable("userId") Long userId) {
+        notificationService.deleteNotificationAll(userId);
         return CommonApiResponse.successResponse(HttpStatus.OK);
     }
 }

--- a/src/main/java/aws/retrospective/dto/GetNotificationResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetNotificationResponseDto.java
@@ -43,7 +43,7 @@ public class GetNotificationResponseDto {
     public static GetNotificationResponseDto of(Notification notification) {
         return new GetNotificationResponseDto(notification.getId(),
             notification.getSection().getId(),
-            notification.getRetrospective().getTitle(), notification.getSender().getId(),
+            notification.getRetrospective().getTitle(), notification.getReceiver().getId(),
             notification.getReceiver().getUsername(), notification.getSender().getThumbnail(),
             notification.getNotificationType(), notification.getCreatedDate());
     }

--- a/src/main/java/aws/retrospective/entity/Notification.java
+++ b/src/main/java/aws/retrospective/entity/Notification.java
@@ -50,7 +50,7 @@ public class Notification extends BaseEntity {
     private Likes likes;
 
     @Enumerated(EnumType.STRING)
-    private NotificationStatus isRead; // 0: unread, 1: read
+    private NotificationStatus isRead; // UNREAD, READ
 
     @Enumerated(EnumType.STRING)
     private NotificationType notificationType; // COMMENT, LIKE

--- a/src/main/java/aws/retrospective/repository/NotificationRepository.java
+++ b/src/main/java/aws/retrospective/repository/NotificationRepository.java
@@ -6,6 +6,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -15,4 +18,10 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Optional<Notification> findNotificationByCommentId(Long commentId);
 
     Optional<Notification> findNotificationByLikesId(Long likesId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Notification SET isRead = :readStatus WHERE isRead = :unReadStatus AND receiver.id = :userId")
+    void readNotificationAll(@Param("readStatus") NotificationStatus readStatus,
+        @Param("unReadStatus") NotificationStatus unReadStatus,
+        @Param("userId") Long userId);
 }

--- a/src/main/java/aws/retrospective/service/NotificationService.java
+++ b/src/main/java/aws/retrospective/service/NotificationService.java
@@ -4,21 +4,26 @@ import aws.retrospective.dto.GetNotificationResponseDto;
 import aws.retrospective.entity.Notification;
 import aws.retrospective.entity.NotificationStatus;
 import aws.retrospective.entity.NotificationRedis;
+import aws.retrospective.entity.User;
 import aws.retrospective.repository.NotificationRedisRepository;
 import aws.retrospective.repository.NotificationRepository;
+import aws.retrospective.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final NotificationRedisRepository redisRepository;
+    private final UserRepository userRepository;
 
     private static final String NOTIFICATION = "notification";
 
@@ -36,6 +41,24 @@ public class NotificationService {
         redisRepository.save(notification);
 
         return convertDto(notificationRedis);
+    }
+
+    // 알림 삭제
+    @Transactional
+    public void deleteNotificationAll(Long userId) {
+        User user = findUserById(userId); // 알림을 받은 사용자 조회
+
+        readNotificationAllByUserId(user); // 사용자가 받은 알림을 모두 읽음 처리
+    }
+
+    private void readNotificationAllByUserId(User user) {
+        notificationRepository.readNotificationAll(NotificationStatus.READ,
+            NotificationStatus.UNREAD, user.getId());
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new NoSuchElementException("사용자를 조회할 수 없습니다. Id : " + userId));
     }
 
     private NotificationRedis findNotification() {


### PR DESCRIPTION
## 개요
- #244 

## 변경 사항

- 알림 전체 삭제 버튼을 누를 시에 해당 사용자가 받은 알림을 모두 읽음 처리 합니다.
- 기존 알림을 모두 조회하는 로직에서 잘못된 부분을 수정합니다.  DTO 변환 과정에서 수신자 정보에 발신자 정보가 저장되는 문제를 수정합니다. notification.getSender() -> notification.getReceiver()

## 테스트

- [ ] API 호출

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!