### PR TITLE
refactor: N+1 문제 수정

### DIFF
--- a/src/main/java/aws/retrospective/dto/GetActionItemsResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetActionItemsResponseDto.java
@@ -1,13 +1,20 @@
 package aws.retrospective.dto;
 
+import aws.retrospective.entity.ActionItem;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class GetActionItemsResponseDto {
 
     private Long userId;
     private String username;
     private String thumbnail;
+
+    public static GetActionItemsResponseDto from(ActionItem actionItem) {
+        return new GetActionItemsResponseDto(actionItem.getUser().getId(),
+            actionItem.getUser().getUsername(), actionItem.getUser().getThumbnail());
+    }
 }

--- a/src/main/java/aws/retrospective/dto/GetCommentDto.java
+++ b/src/main/java/aws/retrospective/dto/GetCommentDto.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 @NoArgsConstructor
 public class GetCommentDto {
 

--- a/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
@@ -4,6 +4,7 @@ import aws.retrospective.entity.ActionItem;
 import aws.retrospective.entity.KudosTarget;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 
@@ -58,7 +59,7 @@ public class GetSectionsResponseDto {
     }
 
     public void addComments(List<GetCommentDto> comments) {
-        this.comments = comments;
+        this.comments = comments == null ? new ArrayList<>() : comments;
     }
 
 }

--- a/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
@@ -36,7 +36,7 @@ public class GetSectionsResponseDto {
 
     private List<GetCommentDto> comments;
 
-    private GetActionItemsResponseDto actionItem;
+    private GetActionItemsResponseDto actionItems;
 
     private GetKudosTargetResponseDto kudosTarget;
 
@@ -53,7 +53,7 @@ public class GetSectionsResponseDto {
         this.sectionName = sectionName;
         this.createdDate = createdDate;
         this.thumbnail = thumbnail;
-        this.actionItem = actionItem == null ? null : GetActionItemsResponseDto.from(actionItem);
+        this.actionItems = actionItem == null ? null : GetActionItemsResponseDto.from(actionItem);
         this.kudosTarget = kudosTarget == null ? null : GetKudosTargetResponseDto.from(kudosTarget);
     }
 

--- a/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
@@ -1,10 +1,9 @@
 package aws.retrospective.dto;
 
+import aws.retrospective.entity.ActionItem;
 import aws.retrospective.entity.KudosTarget;
-import aws.retrospective.entity.Section;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 
@@ -35,16 +34,16 @@ public class GetSectionsResponseDto {
     @Schema(description = "프로필 이미지", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
     private String thumbnail;
 
-    private List<GetCommentDto> comments = new ArrayList<>();
+    private List<GetCommentDto> comments;
 
-    private GetActionItemsResponseDto actionItems;
+    private GetActionItemsResponseDto actionItem;
 
     private GetKudosTargetResponseDto kudosTarget;
 
-    private GetSectionsResponseDto(Long sectionId, Long userId, String username, String content,
+    public GetSectionsResponseDto(Long sectionId, Long userId, String username, String content,
         long likeCnt,
-        String sectionName, LocalDateTime createdDate, List<GetCommentDto> comments,
-        String thumbnail, GetActionItemsResponseDto actionItems,
+        String sectionName, LocalDateTime createdDate,
+        String thumbnail, ActionItem actionItem,
         KudosTarget kudosTarget) {
         this.sectionId = sectionId;
         this.userId = userId;
@@ -53,23 +52,13 @@ public class GetSectionsResponseDto {
         this.likeCnt = likeCnt;
         this.sectionName = sectionName;
         this.createdDate = createdDate;
-        this.comments = comments;
         this.thumbnail = thumbnail;
-        this.actionItems = actionItems;
-        this.kudosTarget = kudosTarget != null ? GetKudosTargetResponseDto.from(kudosTarget) : null;
+        this.actionItem = actionItem == null ? null : GetActionItemsResponseDto.from(actionItem);
+        this.kudosTarget = kudosTarget == null ? null : GetKudosTargetResponseDto.from(kudosTarget);
     }
 
-    public static GetSectionsResponseDto of(Section section, KudosTarget kudosTarget,
-        List<GetCommentDto> comments) {
-        return new GetSectionsResponseDto(section.getId(), section.getUser().getId(),
-            section.getUser().getUsername(),
-            section.getContent(), section.getLikeCnt(),
-            section.getTemplateSection().getSectionName(), section.getCreatedDate(), comments,
-            section.getUser().getThumbnail(),
-            section.getActionItem() != null ? new GetActionItemsResponseDto(
-                section.getActionItem().getUser().getId(),
-                section.getActionItem().getUser().getUsername(),
-                section.getActionItem().getUser().getThumbnail()
-            ) : null, kudosTarget);
+    public void addComments(List<GetCommentDto> comments) {
+        this.comments = comments;
     }
+
 }

--- a/src/main/java/aws/retrospective/entity/Section.java
+++ b/src/main/java/aws/retrospective/entity/Section.java
@@ -10,7 +10,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -48,10 +47,6 @@ public class Section extends BaseEntity {
 
     @OneToMany(mappedBy = "section", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
-
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
-    @JoinColumn(name = "action_item")
-    private ActionItem actionItem;
 
     @Builder
     public Section(String content, Retrospective retrospective, User user,
@@ -91,11 +86,6 @@ public class Section extends BaseEntity {
 
     public boolean isNotActionItemsSection() {
         return !isActionItemsSection();
-    }
-
-    // Action Items 지정
-    public void updateActionItems(ActionItem actionItem) {
-        this.actionItem = actionItem;
     }
 
     public boolean isNotKudosTemplate() {

--- a/src/main/java/aws/retrospective/repository/SectionRepository.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepository.java
@@ -1,13 +1,8 @@
 package aws.retrospective.repository;
 
 import aws.retrospective.entity.Section;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface SectionRepository extends JpaRepository<Section, Long> {
+public interface SectionRepository extends JpaRepository<Section, Long>, SectionRepositoryCustom {
 
-    @Query("select s from Section s join fetch s.retrospective sr left join fetch s.actionItem ac where sr.id = :retrospectiveId")
-    List<Section> getSectionsWithComments(@Param("retrospectiveId") Long retrospectiveId);
 }

--- a/src/main/java/aws/retrospective/repository/SectionRepositoryCustom.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepositoryCustom.java
@@ -1,0 +1,9 @@
+package aws.retrospective.repository;
+
+import aws.retrospective.dto.GetSectionsResponseDto;
+import java.util.List;
+
+public interface SectionRepositoryCustom {
+
+    List<GetSectionsResponseDto> getSectionsAll(Long retrospectiveId);
+}

--- a/src/main/java/aws/retrospective/repository/SectionRepositoryCustomImpl.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepositoryCustomImpl.java
@@ -1,0 +1,85 @@
+package aws.retrospective.repository;
+
+import static aws.retrospective.entity.QActionItem.actionItem;
+import static aws.retrospective.entity.QComment.comment;
+import static aws.retrospective.entity.QKudosTarget.kudosTarget;
+import static aws.retrospective.entity.QSection.section;
+import static aws.retrospective.entity.QUser.user;
+
+import aws.retrospective.dto.GetCommentDto;
+import aws.retrospective.dto.GetSectionsResponseDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class SectionRepositoryCustomImpl implements SectionRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<GetSectionsResponseDto> getSectionsAll(Long retrospectiveId) {
+
+        // 댓글을 제외한 ActionItem, Kudos, Section 조회
+        List<GetSectionsResponseDto> result = getSections(retrospectiveId);
+
+        // result에 포함된 모든 Section의 ID 조회
+        List<Long> sectionIds = getSectionIds(result);
+
+        // Section ID와 일치하는 댓글 조회
+        List<GetCommentDto> comments = getComments(sectionIds);
+
+        // comments에 등록된 댓글을 Map으로 변환 key:value=comment.id:comment
+        // 아래에서 루프를 돌 때, IN 절을 사용하기 위해 id로 매핑
+        Map<Long, List<GetCommentDto>> collect = createCommentMap(comments);
+
+        // result에는 댓글 정보가 포함되어 있지 않기 때문에 루프를 돌면서 컬렉션 추가
+        result.forEach(
+            section -> section.addComments(collect.get(section.getSectionId()))
+        );
+
+        return result;
+    }
+
+    private static Map<Long, List<GetCommentDto>> createCommentMap(List<GetCommentDto> comments) {
+        return comments.stream()
+            .collect(Collectors.groupingBy(GetCommentDto::getCommentId));
+    }
+
+    private List<GetCommentDto> getComments(List<Long> sectionIds) {
+        return queryFactory
+            .select(Projections.constructor(GetCommentDto.class,
+                comment.id, comment.user.id, comment.content, comment.user.username,
+                comment.user.thumbnail))
+            .from(comment)
+            .join(comment.user, user)
+            .where(comment.id.in(sectionIds))
+            .fetch();
+    }
+
+    private static List<Long> getSectionIds(List<GetSectionsResponseDto> result) {
+        return result.stream()
+            .map(s -> s.getSectionId())
+            .toList();
+    }
+
+    private List<GetSectionsResponseDto> getSections(Long retrospectiveId) {
+        return queryFactory
+            .select(Projections.constructor(GetSectionsResponseDto.class,
+                section.id, section.user.id, section.user.username, section.content,
+                section.likeCnt, section.templateSection.sectionName, section.createdDate,
+                section.user.thumbnail, section.actionItem, kudosTarget
+            ))
+            .from(section)
+            .leftJoin(section.actionItem, actionItem)
+            .leftJoin(kudosTarget).on(kudosTarget.section.eq(section))
+            .leftJoin(section.comments, comment)
+            .where(section.retrospective.id.eq(retrospectiveId))
+            .fetch();
+    }
+}

--- a/src/main/java/aws/retrospective/repository/SectionRepositoryCustomImpl.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepositoryCustomImpl.java
@@ -73,10 +73,10 @@ public class SectionRepositoryCustomImpl implements SectionRepositoryCustom {
             .select(Projections.constructor(GetSectionsResponseDto.class,
                 section.id, section.user.id, section.user.username, section.content,
                 section.likeCnt, section.templateSection.sectionName, section.createdDate,
-                section.user.thumbnail, section.actionItem, kudosTarget
+                section.user.thumbnail, actionItem, kudosTarget
             ))
             .from(section)
-            .leftJoin(section.actionItem, actionItem)
+            .leftJoin(actionItem).on(actionItem.section.eq(section))
             .leftJoin(kudosTarget).on(kudosTarget.section.eq(section))
             .leftJoin(section.comments, comment)
             .where(section.retrospective.id.eq(retrospectiveId))

--- a/src/main/java/aws/retrospective/service/SectionService.java
+++ b/src/main/java/aws/retrospective/service/SectionService.java
@@ -7,7 +7,6 @@ import aws.retrospective.dto.CreateSectionDto;
 import aws.retrospective.dto.CreateSectionResponseDto;
 import aws.retrospective.dto.EditSectionRequestDto;
 import aws.retrospective.dto.EditSectionResponseDto;
-import aws.retrospective.dto.GetCommentDto;
 import aws.retrospective.dto.GetSectionsRequestDto;
 import aws.retrospective.dto.GetSectionsResponseDto;
 import aws.retrospective.dto.IncreaseSectionLikesResponseDto;
@@ -31,11 +30,9 @@ import aws.retrospective.repository.SectionRepository;
 import aws.retrospective.repository.TeamRepository;
 import aws.retrospective.repository.TemplateSectionRepository;
 import aws.retrospective.repository.UserRepository;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -66,11 +63,7 @@ public class SectionService {
         // 다른 팀의 회고 보드를 조회 할 수 없다
         validateTeamAccess(request.getTeamId(), findRetrospective);
 
-        // 회고 카드 전체 조회
-        List<Section> sections = sectionRepository.getSectionsWithComments(
-            request.getRetrospectiveId());
-
-        return convertSectionToResponse(sections);
+        return sectionRepository.getSectionsAll(request.getRetrospectiveId());
     }
 
     // 회고 카드 생성 API
@@ -234,15 +227,6 @@ public class SectionService {
             .build();
     }
 
-    private List<GetSectionsResponseDto> convertSectionToResponse(List<Section> sections) {
-        List<GetSectionsResponseDto> response = new ArrayList<>();
-        for (Section section : sections) {
-            response.add(
-                GetSectionsResponseDto.of(section, getKudosTarget(section), getComments(section)));
-        }
-        return response;
-    }
-
     private Team getTeam(Long teamId) {
         return teamRepository.findById(teamId)
             .orElseThrow(() -> new NoSuchElementException("Not Found Team id : " + teamId));
@@ -273,16 +257,6 @@ public class SectionService {
      */
     private KudosTarget assignKudos(Section section, User user) {
         return kudosRepository.save(KudosTarget.createKudosTarget(section, user));
-    }
-
-    private KudosTarget getKudosTarget(Section section) {
-        return kudosRepository.findBySection(section).orElse(null);
-    }
-
-    private static List<GetCommentDto> getComments(Section section) {
-        return section.getComments().stream()
-            .map(GetCommentDto::from)
-            .collect(Collectors.toList());
     }
 
     private void validateTemplateMatch(Retrospective retrospective, TemplateSection templateSection) {

--- a/src/main/java/aws/retrospective/service/SectionService.java
+++ b/src/main/java/aws/retrospective/service/SectionService.java
@@ -142,10 +142,10 @@ public class SectionService {
         // Action Items 유형인지 확인한다.
         validateActionItems(section);
 
-        // Action Item을 가져온다.
-        ActionItem actionItem = section.getActionItem();
         // Action Item에 지정할 사용자를 조회한다.
         User assignUser = getAssignUser(request);
+
+        ActionItem actionItem = getActionItem(section);
 
         /**
          * Action Item이 없을 때는 새로 생성하고, 있을 때는 사용자를 지정한다.
@@ -157,6 +157,10 @@ public class SectionService {
             // 기존에 등록된 Action Item에 새로운 사용자를 지정한다.
             actionItem.assignUser(assignUser);
         }
+    }
+
+    private ActionItem getActionItem(Section section) {
+        return actionItemRepository.findBySectionId(section.getId()).orElse(null);
     }
 
     // 회고카드 삭제
@@ -336,9 +340,7 @@ public class SectionService {
     private void assignActionItem(User user, Team team, Section section,
         Retrospective retrospective) {
         // Action Item 생성
-        ActionItem savedActionItem = actionItemRepository.save(
-            createActionItem(user, team, section, retrospective));
-        section.updateActionItems(savedActionItem); // 생성된 Action Item을 Section에 지정한다.
+        actionItemRepository.save(createActionItem(user, team, section, retrospective));
     }
 
     private AssignKudosResponseDto convertAssignKudosResponse(KudosTarget kudosTarget) {

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -16,6 +16,7 @@ import aws.retrospective.dto.CreateSectionResponseDto;
 import aws.retrospective.dto.DeleteSectionRequestDto;
 import aws.retrospective.dto.EditSectionRequestDto;
 import aws.retrospective.dto.EditSectionResponseDto;
+import aws.retrospective.dto.GetCommentDto;
 import aws.retrospective.dto.GetSectionsRequestDto;
 import aws.retrospective.dto.GetSectionsResponseDto;
 import aws.retrospective.dto.IncreaseSectionLikesRequestDto;
@@ -273,14 +274,22 @@ class SectionServiceTest {
         createdSection.getComments().add(comment1);
         createdSection.getComments().add(comment2);
 
-        when(sectionRepository.getSectionsWithComments(retrospectiveId)).thenReturn(
-            List.of(createdSection));
+        GetSectionsResponseDto dto = new GetSectionsResponseDto(
+            sectionId, createdUser.getId(), createdUser.getUsername(), createdSection.getContent(),
+            createdSection.getLikeCnt(), createdSection.getTemplateSection().getSectionName(),
+            createdSection.getCreatedDate(), createdSection.getUser().getThumbnail(),
+            null, null
+        );
+        dto.addComments(List.of(GetCommentDto.from(comment1), GetCommentDto.from(comment2)));
+
+        when(sectionRepository.getSectionsAll(retrospectiveId)).thenReturn(List.of(dto));
 
         //when
         GetSectionsRequestDto request = new GetSectionsRequestDto();
         ReflectionTestUtils.setField(request, "retrospectiveId", retrospectiveId);
         ReflectionTestUtils.setField(request, "teamId", teamId);
         List<GetSectionsResponseDto> results = sectionService.getSections(request);
+
 
         //then
         assertThat(results.size()).isEqualTo(1);


### PR DESCRIPTION
## 개요
- #248 

## 변경 사항

- QueryDsl 도입
- 기존의 SectionService.convertSectionToResponse()에서 Section 개수만큼 N+1 문제가 발생하던 부분을 개선하였습니다.
반복문을 통해 조회하던 방식에서 IN 절로 한 번에 조회하도록 수정.
기존 : 조회 쿼리문 14회 발생(각 Section마다 연관관계에 있는 엔티티를 추가로 조회), 70ms 소요
개선 : 조회 쿼리문 2회 발생(Section 조회, 댓글 조회), 31ms 소요
- Section 엔티티에서 ActionItem 필드를 제거하였습니다. Section에 ActionItem이 지정되지 않으면 불필요하게 NULL 값을 차지하는 문제가 있었습니다. 또한 새로운 ActionItem을 생성하였을 때 Section의 ActionItem필드에 저장하기 위한 불필요한 UPDATE를 호출해야하는 문제도 있었습니다. 

![스크린샷 2024-07-02 오후 9 54 33](https://github.com/donga-it-club/past-foward-backend/assets/122812652/d4b99b05-9760-4c33-8dc2-bd794093be01)
<img width="725" alt="스크린샷 2024-07-03 오전 1 01 37" src="https://github.com/donga-it-club/past-foward-backend/assets/122812652/16f765de-2179-4b99-9a5c-6d7991298aac">


## 테스트

- [x] 테스트 코드
- [x] API 호출

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!