### PR TITLE
feat: 응답 dto에 팀, 회고보드 id 필드 추가

### DIFF
--- a/src/main/java/aws/retrospective/dto/GetNotificationResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetNotificationResponseDto.java
@@ -26,11 +26,15 @@ public class GetNotificationResponseDto {
     private NotificationType notificationType;
     @Schema(description = "알림 발생 시간", example = "2021-07-01T00:00:00")
     private LocalDateTime dateTime;
+    @Schema(description = "회고 보드 ID", example = "1")
+    private Long retrospectiveId;
+    @Schema(description = "팀 ID", example = "1")
+    private Long teamId;
 
     private GetNotificationResponseDto(Long notificationId, Long sectionId,
         String retrospectiveTitle, Long receiverId,
         String senderName, String thumbnail, NotificationType notificationType,
-        LocalDateTime dateTime) {
+        LocalDateTime dateTime, Long retrospectiveId, Long teamId) {
         this.notificationId = notificationId;
         this.sectionId = sectionId;
         this.retrospectiveTitle = retrospectiveTitle;
@@ -39,6 +43,8 @@ public class GetNotificationResponseDto {
         this.thumbnail = thumbnail;
         this.notificationType = notificationType;
         this.dateTime = parseDateTime(dateTime.toString());
+        this.retrospectiveId = retrospectiveId;
+        this.teamId = teamId;
     }
 
     public static GetNotificationResponseDto of(Notification notification) {
@@ -46,7 +52,10 @@ public class GetNotificationResponseDto {
             notification.getSection().getId(),
             notification.getRetrospective().getTitle(), notification.getReceiver().getId(),
             notification.getReceiver().getUsername(), notification.getSender().getThumbnail(),
-            notification.getNotificationType(), notification.getCreatedDate());
+            notification.getNotificationType(), notification.getCreatedDate(),
+            notification.getRetrospective().getId(),
+            notification.getRetrospective().getTeam() == null ? null
+                : notification.getRetrospective().getTeam().getId());
     }
 
     private LocalDateTime parseDateTime(String dateTime) {

--- a/src/test/java/aws/retrospective/service/NotificationServiceTest.java
+++ b/src/test/java/aws/retrospective/service/NotificationServiceTest.java
@@ -9,14 +9,18 @@ import aws.retrospective.entity.NotificationType;
 import aws.retrospective.entity.Retrospective;
 import aws.retrospective.entity.RetrospectiveTemplate;
 import aws.retrospective.entity.Section;
+import aws.retrospective.entity.Team;
 import aws.retrospective.entity.User;
 import aws.retrospective.entity.NotificationRedis;
+import aws.retrospective.entity.UserTeam;
 import aws.retrospective.repository.NotificationRedisRepository;
 import aws.retrospective.repository.NotificationRepository;
 import aws.retrospective.repository.RetrospectiveRepository;
 import aws.retrospective.repository.RetrospectiveTemplateRepository;
 import aws.retrospective.repository.SectionRepository;
+import aws.retrospective.repository.TeamRepository;
 import aws.retrospective.repository.UserRepository;
+import aws.retrospective.repository.UserTeamRepository;
 import aws.retrospective.util.TestUtil;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -51,6 +55,10 @@ class NotificationServiceTest {
     SectionService sectionService;
     @Autowired
     NotificationRepository notificationRepository;
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private UserTeamRepository userTeamRepository;
 
     @AfterEach
     public void tearDown() {
@@ -147,11 +155,17 @@ class NotificationServiceTest {
             .build();
         User savedUser = userRepository.save(user);
 
+        Team team = TestUtil.createTeam();
+        Team savedTeam = teamRepository.save(team);
+
+        UserTeam userTeam = UserTeam.builder().user(savedUser).team(savedTeam).build();
+        UserTeam savedUserTeam = userTeamRepository.save(userTeam);
+
         RetrospectiveTemplate template = RetrospectiveTemplate.builder().name("KPT").build();
         templateRepository.save(template);
 
         Retrospective retrospective = Retrospective.builder().title("title").user(user)
-            .template(template).build();
+            .template(template).team(savedTeam).build();
         retrospectiveRepository.save(retrospective);
 
         Section section = Section.builder().user(user).retrospective(retrospective)
@@ -191,5 +205,7 @@ class NotificationServiceTest {
         assertThat(notification.getSenderName()).isEqualTo(savedUser.getUsername());
         assertThat(notification.getThumbnail()).isEqualTo(savedUser.getThumbnail());
         assertThat(notification.getNotificationType()).isEqualTo(NotificationType.LIKE);
+        assertThat(notification.getTeamId()).isEqualTo(savedTeam.getId());
+        assertThat(notification.getRetrospectiveId()).isEqualTo(retrospective.getId());
     }
 }


### PR DESCRIPTION
## 개요
- #269 

## 변경 사항

- 알림을 눌렀을 때, 알림이 발생한 회고로 이동할 수 있도록 필드를 추가합니다.

## 테스트

- [ ] 어떻게 이 변경 사항을 테스트했는지
- [ ] 어떤 환경에서 테스트가 이루어졌는지 (예: 로컬 개발 환경, 스테이징 환경)

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!