### PR TITLE
fix: 응답 dto에 comments가 정상적으로 조회되도록 수정합니다.

### DIFF
--- a/src/main/java/aws/retrospective/dto/GetCommentDto.java
+++ b/src/main/java/aws/retrospective/dto/GetCommentDto.java
@@ -2,6 +2,7 @@ package aws.retrospective.dto;
 
 import aws.retrospective.entity.Comment;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,6 +13,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class GetCommentDto {
 
+    @Schema(description = "회고카드 id", example = "1")
+    Long sectionId;
     @Schema(description = "댓글 id", example = "1")
     private Long commentId;
     @Schema(description = "작성자 id", example = "1")
@@ -22,9 +25,13 @@ public class GetCommentDto {
     private String username;
     @Schema(description = "프로필 이미지", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
     private String thumbnail;
+    @Schema(description = "댓글 등록일", example = "2021-07-01T00:00:00")
+    private LocalDateTime createdDate;
+    @Schema(description = "댓글 수정일", example = "2021-07-01T00:00:00")
+    private LocalDateTime lastModifiedDate;
 
     public static GetCommentDto from(Comment comment) {
-        return new GetCommentDto(comment.getId(), comment.getUser().getId(), comment.getContent(),
-            comment.getUser().getUsername(), comment.getUser().getThumbnail());
+        return new GetCommentDto(comment.getSection().getId(), comment.getId(), comment.getUser().getId(), comment.getContent(),
+            comment.getUser().getUsername(), comment.getUser().getThumbnail(), comment.getCreatedDate(), comment.getUpdatedDate());
     }
 }

--- a/src/main/java/aws/retrospective/repository/SectionRepositoryCustomImpl.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepositoryCustomImpl.java
@@ -48,14 +48,14 @@ public class SectionRepositoryCustomImpl implements SectionRepositoryCustom {
 
     private static Map<Long, List<GetCommentDto>> createCommentMap(List<GetCommentDto> comments) {
         return comments.stream()
-            .collect(Collectors.groupingBy(GetCommentDto::getCommentId));
+            .collect(Collectors.groupingBy(GetCommentDto::getSectionId));
     }
 
     private List<GetCommentDto> getComments(List<Long> sectionIds) {
         return queryFactory
             .select(Projections.constructor(GetCommentDto.class,
-                comment.id, comment.user.id, comment.content, comment.user.username,
-                comment.user.thumbnail))
+                comment.section.id, comment.id, comment.user.id, comment.content, comment.user.username,
+                comment.user.thumbnail, comment.createdDate, comment.updatedDate))
             .from(comment)
             .join(comment.user, user)
             .where(comment.id.in(sectionIds))


### PR DESCRIPTION
## 개요
- #274 

## 변경 사항

- createCommentMap()에서 그룹핑을 comment.id 기준으로 묶어서 생성하고, section.addComments(collect.get(section.getSectionId()))에서 section.id를 기준으로 조회하던 코드를 수정합니다.
그룹핑 comment.id -> section.id
 - 댓글이 작성된 시간과 수정된 시간을 추가합니다.

## 테스트

- [ ] 어떻게 이 변경 사항을 테스트했는지
- [ ] 어떤 환경에서 테스트가 이루어졌는지 (예: 로컬 개발 환경, 스테이징 환경)

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!