### PR TITLE
fix: select where절 변경

### DIFF
--- a/src/main/java/aws/retrospective/repository/SectionRepositoryCustomImpl.java
+++ b/src/main/java/aws/retrospective/repository/SectionRepositoryCustomImpl.java
@@ -58,7 +58,7 @@ public class SectionRepositoryCustomImpl implements SectionRepositoryCustom {
                 comment.user.thumbnail, comment.createdDate, comment.updatedDate))
             .from(comment)
             .join(comment.user, user)
-            .where(comment.id.in(sectionIds))
+            .where(comment.section.id.in(sectionIds))
             .fetch();
     }
 


### PR DESCRIPTION
## 개요
- #276 

## 변경 사항

- 기존에 경우 where절의 조건으로 comment.id가 들어갔는데, 회고 카드에 대한 comment를 가져와야 하므로 comment.section.id로 변경합니다.

## 테스트

- [ ] 어떻게 이 변경 사항을 테스트했는지
- [ ] 어떤 환경에서 테스트가 이루어졌는지 (예: 로컬 개발 환경, 스테이징 환경)

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!