### PR TITLE
fix: 삭제된 회고 보드를 알림 조회 시에 포함하지 않도록 수정

### DIFF
--- a/src/main/java/aws/retrospective/repository/NotificationRepository.java
+++ b/src/main/java/aws/retrospective/repository/NotificationRepository.java
@@ -2,24 +2,17 @@ package aws.retrospective.repository;
 
 import aws.retrospective.entity.Notification;
 import aws.retrospective.entity.NotificationStatus;
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
-
-    List<Notification> findByIsReadOrCreatedDateAfter(NotificationStatus isRead,
-        LocalDateTime createdDate);
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
 
     Optional<Notification> findNotificationByCommentId(Long commentId);
 
     Optional<Notification> findNotificationByLikesId(Long likesId);
-
-    Notification findFirstByOrderByCreatedDateDesc();
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Notification SET isRead = :readStatus WHERE isRead = :unReadStatus AND receiver.id = :userId")

--- a/src/main/java/aws/retrospective/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/aws/retrospective/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,10 @@
+package aws.retrospective.repository;
+
+import aws.retrospective.entity.Notification;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface NotificationRepositoryCustom {
+
+    List<Notification> findUnReadAndNewNotifications(LocalDateTime lastNotificationTime);
+}

--- a/src/main/java/aws/retrospective/repository/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/aws/retrospective/repository/NotificationRepositoryCustomImpl.java
@@ -1,0 +1,39 @@
+package aws.retrospective.repository;
+
+import static aws.retrospective.entity.QNotification.notification;
+import static aws.retrospective.entity.QRetrospective.retrospective;
+
+import aws.retrospective.entity.Notification;
+import aws.retrospective.entity.NotificationStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPQLQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom {
+
+    private final JPQLQueryFactory queryFactory;
+
+    @Override
+    public List<Notification> findUnReadAndNewNotifications(LocalDateTime lastNotificationTime) {
+        return queryFactory
+            .selectFrom(notification)
+            .where(eqNotDeletedRetrospective().or(eqUnReadNotification())
+                .or(gtNotificationTime(lastNotificationTime)))
+            .fetch();
+    }
+
+    private BooleanExpression eqNotDeletedRetrospective() {
+        return retrospective.deletedDate.isNotNull();
+    }
+
+    private BooleanExpression eqUnReadNotification() {
+        return notification.isRead.eq(NotificationStatus.UNREAD);
+    }
+
+    private BooleanExpression gtNotificationTime(LocalDateTime lastNotificationTime) {
+        return notification.createdDate.gt(lastNotificationTime);
+    }
+}

--- a/src/main/java/aws/retrospective/service/NotificationService.java
+++ b/src/main/java/aws/retrospective/service/NotificationService.java
@@ -11,14 +11,8 @@ import aws.retrospective.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
-
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -79,8 +73,9 @@ public class NotificationService {
     }
 
     private List<GetNotificationResponseDto> convertDto(NotificationRedis notificationRedis) {
-        return notificationRepository.findByIsReadOrCreatedDateAfter(
-                NotificationStatus.UNREAD, notificationRedis.getLastNotificationTime()).stream()
+        return notificationRepository.findUnReadAndNewNotifications(
+                notificationRedis.getLastNotificationTime())
+            .stream()
             .map(GetNotificationResponseDto::of)
             .toList();
     }


### PR DESCRIPTION
## 개요
- #280 

## 변경 사항

- 알림 조회 시에 삭제된 회고 보드(soft delete)를 같이 조회하면서 발생하는 오류를 수정합니다.

## 테스트

- [x] api 호출
- [x] 로컬 테스트

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!