### PR TITLE
fix: senderName에 알림을 발생시킨 사용자의 이름으로 저장

### DIFF
--- a/src/main/java/aws/retrospective/dto/GetNotificationResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetNotificationResponseDto.java
@@ -51,7 +51,7 @@ public class GetNotificationResponseDto {
         return new GetNotificationResponseDto(notification.getId(),
             notification.getSection().getId(),
             notification.getRetrospective().getTitle(), notification.getReceiver().getId(),
-            notification.getReceiver().getUsername(), notification.getSender().getThumbnail(),
+            notification.getSender().getUsername(), notification.getSender().getThumbnail(),
             notification.getNotificationType(), notification.getCreatedDate(),
             notification.getRetrospective().getId(),
             notification.getRetrospective().getTeam() == null ? null


### PR DESCRIPTION
## 개요
- #286 

## 변경 사항

- senderName 필드에 알림을 발생시킨 사용자의 이름으로 수정

## 테스트

- [ ] 어떻게 이 변경 사항을 테스트했는지
- [ ] 어떤 환경에서 테스트가 이루어졌는지 (예: 로컬 개발 환경, 스테이징 환경)

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!