### PR TITLE
fix: section 삭제 시 외래키 문제 해결

### DIFF
--- a/src/main/java/aws/retrospective/entity/Section.java
+++ b/src/main/java/aws/retrospective/entity/Section.java
@@ -48,6 +48,9 @@ public class Section extends BaseEntity {
     @OneToMany(mappedBy = "section", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
+    @OneToMany(mappedBy = "section", cascade = CascadeType.REMOVE)
+    private List<Notification> notifications = new ArrayList<>();
+
     @Builder
     public Section(String content, Retrospective retrospective, User user,
         TemplateSection templateSection) {


### PR DESCRIPTION
## 개요
- 무엇을 위한 PR인지, 어떠한 이유로 해당 PR을 열게 되었는지에 대한 개요를 적어주세요!
- #299 

## 변경 사항

- `comment`가 달린 `section` 삭제 시에 `외래키` 문제를 해결한다.
`Notification` 엔티티는 `section`과 `comment`를 외래키로 포함하고 있기 때문에, `Section` 엔티티에 `List<Notification>`을 포함하고 `cascade` 옵션을 건다.
```
@Entity
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class Notification extends BaseEntity {

    .. 생략

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "section_id")
    private Section section;
    
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "comment_id")
    private Comment comment;
}

```

## 테스트

- [ ] 어떻게 이 변경 사항을 테스트했는지
- [ ] 어떤 환경에서 테스트가 이루어졌는지 (예: 로컬 개발 환경, 스테이징 환경)

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!