### PR TITLE
refactor: 회고카드 생성 및 조회 캐싱 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 
     // Spring Data Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // LocalDateTime 타입 직렬화
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/aws/retrospective/RetrospectiveApplication.java
+++ b/src/main/java/aws/retrospective/RetrospectiveApplication.java
@@ -2,10 +2,12 @@ package aws.retrospective;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class RetrospectiveApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/aws/retrospective/config/AppConfig.java
+++ b/src/main/java/aws/retrospective/config/AppConfig.java
@@ -1,0 +1,15 @@
+package aws.retrospective.config;
+
+import aws.retrospective.util.ObjectMapperFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return ObjectMapperFactory.getInstance();
+    }
+}

--- a/src/main/java/aws/retrospective/config/RedisCacheConfig.java
+++ b/src/main/java/aws/retrospective/config/RedisCacheConfig.java
@@ -1,0 +1,43 @@
+package aws.retrospective.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        // ObjectMapper 설정: JavaTimeModule 추가 및 ISO-8601 포맷으로 날짜 직렬화
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(
+            SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // 날짜를 배열이 아닌 ISO 형식으로 직렬화
+
+        // Jackson Serializer에 ObjectMapper 전달
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(
+            objectMapper);
+
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofHours(1)) // 캐시 유효 기간 설정
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                new StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(serializer));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
+            .build();
+    }
+}

--- a/src/main/java/aws/retrospective/config/RedisCacheConfig.java
+++ b/src/main/java/aws/retrospective/config/RedisCacheConfig.java
@@ -1,9 +1,8 @@
 package aws.retrospective.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
+import lombok.RequiredArgsConstructor;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,16 +14,13 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@RequiredArgsConstructor
 public class RedisCacheConfig {
+
+    private final ObjectMapper objectMapper;
 
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
-        // ObjectMapper 설정: JavaTimeModule 추가 및 ISO-8601 포맷으로 날짜 직렬화
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.disable(
-            SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // 날짜를 배열이 아닌 ISO 형식으로 직렬화
-
         // Jackson Serializer에 ObjectMapper 전달
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(
             objectMapper);

--- a/src/main/java/aws/retrospective/config/RedisConfig.java
+++ b/src/main/java/aws/retrospective/config/RedisConfig.java
@@ -1,12 +1,10 @@
 package aws.retrospective.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -14,7 +12,7 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableJpaRepositories(basePackages = "aws.retrospective.repository")
+@RequiredArgsConstructor
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")
@@ -22,6 +20,8 @@ public class RedisConfig {
 
     @Value("${spring.data.redis.port}")
     private int port;
+
+    private final ObjectMapper objectMapper;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
@@ -32,11 +32,6 @@ public class RedisConfig {
     public RedisTemplate<String, Object> redisTemplate() {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(redisConnectionFactory());
-
-        // ObjectMapper 설정
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule()); // Java 8 날짜/시간 모듈 등록
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식 사용
 
         // Jackson을 이용한 RedisSerializer 설정
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(

--- a/src/main/java/aws/retrospective/config/RedisConfig.java
+++ b/src/main/java/aws/retrospective/config/RedisConfig.java
@@ -1,11 +1,17 @@
 package aws.retrospective.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableJpaRepositories(basePackages = "aws.retrospective.repository")
@@ -20,5 +26,28 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+
+        // ObjectMapper 설정
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); // Java 8 날짜/시간 모듈 등록
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식 사용
+
+        // Jackson을 이용한 RedisSerializer 설정
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(
+            objectMapper);
+
+        // RedisTemplate 설정
+        template.setKeySerializer(new StringRedisSerializer()); // 키는 문자열로 직렬화
+        template.setValueSerializer(serializer);  // 값은 JSON 직렬화
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
+
+        return template;
     }
 }

--- a/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
+++ b/src/main/java/aws/retrospective/dto/GetSectionsResponseDto.java
@@ -2,6 +2,8 @@ package aws.retrospective.dto;
 
 import aws.retrospective.entity.ActionItem;
 import aws.retrospective.entity.KudosTarget;
+import aws.retrospective.entity.Section;
+import aws.retrospective.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -63,4 +65,18 @@ public class GetSectionsResponseDto {
         this.comments = comments == null ? new ArrayList<>() : comments;
     }
 
+    public static GetSectionsResponseDto from(Section section, User user) {
+        return new GetSectionsResponseDto(
+            section.getId(),
+            user.getId(),
+            user.getUsername(),
+            section.getContent(),
+            section.getLikeCnt(),
+            section.getTemplateSection().getSectionName(),
+            section.getCreatedDate(),
+            user.getThumbnail(),
+            null,
+            null
+        );
+    }
 }

--- a/src/main/java/aws/retrospective/event/SectionCacheDeleteEvent.java
+++ b/src/main/java/aws/retrospective/event/SectionCacheDeleteEvent.java
@@ -1,0 +1,12 @@
+package aws.retrospective.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class SectionCacheDeleteEvent {
+
+    private Long retrospectiveId;
+
+}

--- a/src/main/java/aws/retrospective/event/SectionCacheListener.java
+++ b/src/main/java/aws/retrospective/event/SectionCacheListener.java
@@ -4,12 +4,14 @@ import aws.retrospective.dto.GetSectionsResponseDto;
 import aws.retrospective.repository.CacheRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SectionCacheListener {
 
     private final CacheRepository<List<GetSectionsResponseDto>> cacheRepository;
@@ -19,13 +21,19 @@ public class SectionCacheListener {
         String cacheKey = String.format("%s::%d", cacheRepository.getCacheKey(),
             event.getRetrospectiveId());
 
-        // 캐싱된 데이터를 가져온다.
-        List<GetSectionsResponseDto> cachingData = cacheRepository.getCacheDate(cacheKey);
+        try {
+            // 캐싱된 데이터를 가져온다.
+            List<GetSectionsResponseDto> cachingData = cacheRepository.getCacheDate(cacheKey);
 
-        // 캐싱된 값이 존재할 경우 생성된 회고 카드를 추가한다.
-        if (cachingData != null && !cachingData.isEmpty()) {
-            cachingData.add(GetSectionsResponseDto.from(event.getSection(), event.getUser()));
-            cacheRepository.saveCacheData(cacheKey, cachingData);
+            // 캐싱된 값이 존재할 경우 생성된 회고 카드를 추가한다.
+            if (cachingData != null && !cachingData.isEmpty()) {
+                cachingData.add(GetSectionsResponseDto.from(event.getSection(), event.getUser()));
+                cacheRepository.saveCacheData(cacheKey, cachingData);
+            }
+        } catch (Exception ex) { // TODO 커스텀 예외 생성한다.
+            // 캐싱되어 있는 데이터를 삭제한다.
+            cacheRepository.deleteCacheData(cacheKey);
+            log.error("캐싱 데이터 갱신 중 오류가 발생했습니다.", ex);
         }
     }
 }

--- a/src/main/java/aws/retrospective/event/SectionCacheListener.java
+++ b/src/main/java/aws/retrospective/event/SectionCacheListener.java
@@ -1,0 +1,31 @@
+package aws.retrospective.event;
+
+import aws.retrospective.dto.GetSectionsResponseDto;
+import aws.retrospective.repository.CacheRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Service
+@RequiredArgsConstructor
+public class SectionCacheListener {
+
+    private final CacheRepository<List<GetSectionsResponseDto>> cacheRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void updateCacheWithNewSection(SectionCacheUpdateEvent event) {
+        String cacheKey = String.format("%s::%d", cacheRepository.getCacheKey(),
+            event.getRetrospectiveId());
+
+        // 캐싱된 데이터를 가져온다.
+        List<GetSectionsResponseDto> cachingData = cacheRepository.getCacheDate(cacheKey);
+
+        // 캐싱된 값이 존재할 경우 생성된 회고 카드를 추가한다.
+        if (cachingData != null && !cachingData.isEmpty()) {
+            cachingData.add(GetSectionsResponseDto.from(event.getSection(), event.getUser()));
+            cacheRepository.saveCacheData(cacheKey, cachingData);
+        }
+    }
+}

--- a/src/main/java/aws/retrospective/event/SectionCacheListener.java
+++ b/src/main/java/aws/retrospective/event/SectionCacheListener.java
@@ -36,4 +36,12 @@ public class SectionCacheListener {
             log.error("캐싱 데이터 갱신 중 오류가 발생했습니다.", ex);
         }
     }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void deleteCacheHandle(SectionCacheDeleteEvent event) {
+        String cacheKey = String.format("%s::%d", cacheRepository.getCacheKey(),
+            event.getRetrospectiveId());
+        cacheRepository.deleteCacheData(cacheKey);
+    }
+
 }

--- a/src/main/java/aws/retrospective/event/SectionCacheUpdateEvent.java
+++ b/src/main/java/aws/retrospective/event/SectionCacheUpdateEvent.java
@@ -1,0 +1,16 @@
+package aws.retrospective.event;
+
+import aws.retrospective.entity.Section;
+import aws.retrospective.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class SectionCacheUpdateEvent {
+
+    private Long retrospectiveId;
+    private Section section;
+    private User user;
+
+}

--- a/src/main/java/aws/retrospective/repository/CacheRepository.java
+++ b/src/main/java/aws/retrospective/repository/CacheRepository.java
@@ -1,7 +1,12 @@
 package aws.retrospective.repository;
 
 // 캐싱과 관련한 기능을 제공하는 인터페이스
-public interface CacheRepository {
+public interface CacheRepository<T> {
 
     String getCacheKey();
+
+    T getCacheDate(String cacheKey);
+
+    void saveCacheData(String cacheKey, T data);
+
 }

--- a/src/main/java/aws/retrospective/repository/CacheRepository.java
+++ b/src/main/java/aws/retrospective/repository/CacheRepository.java
@@ -1,0 +1,7 @@
+package aws.retrospective.repository;
+
+// 캐싱과 관련한 기능을 제공하는 인터페이스
+public interface CacheRepository {
+
+    String getCacheKey();
+}

--- a/src/main/java/aws/retrospective/repository/CacheRepository.java
+++ b/src/main/java/aws/retrospective/repository/CacheRepository.java
@@ -9,4 +9,5 @@ public interface CacheRepository<T> {
 
     void saveCacheData(String cacheKey, T data);
 
+    void deleteCacheData(String cacheKey);
 }

--- a/src/main/java/aws/retrospective/repository/SectionCacheRepository.java
+++ b/src/main/java/aws/retrospective/repository/SectionCacheRepository.java
@@ -1,0 +1,16 @@
+package aws.retrospective.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SectionCacheRepository implements CacheRepository {
+
+    public static final String CACHE_KEY = "sectionsInRetrospective-cache";
+
+    private final String cacheKey = CACHE_KEY;
+
+    @Override
+    public String getCacheKey() {
+        return cacheKey;
+    }
+}

--- a/src/main/java/aws/retrospective/repository/SectionCacheRepository.java
+++ b/src/main/java/aws/retrospective/repository/SectionCacheRepository.java
@@ -29,4 +29,9 @@ public class SectionCacheRepository implements CacheRepository {
     public void saveCacheData(String cacheKey, Object data) {
         redisTemplate.opsForValue().set(cacheKey, data);
     }
+
+    @Override
+    public void deleteCacheData(String cacheKey) {
+        redisTemplate.delete(cacheKey);
+    }
 }

--- a/src/main/java/aws/retrospective/repository/SectionCacheRepository.java
+++ b/src/main/java/aws/retrospective/repository/SectionCacheRepository.java
@@ -1,16 +1,32 @@
 package aws.retrospective.repository;
 
+import aws.retrospective.dto.GetSectionsResponseDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@RequiredArgsConstructor
 public class SectionCacheRepository implements CacheRepository {
 
     public static final String CACHE_KEY = "sectionsInRetrospective-cache";
-
     private final String cacheKey = CACHE_KEY;
+
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     public String getCacheKey() {
         return cacheKey;
+    }
+
+    @Override
+    public List<GetSectionsResponseDto> getCacheDate(String cacheKey) {
+        return (List<GetSectionsResponseDto>) redisTemplate.opsForValue().get(cacheKey);
+    }
+
+    @Override
+    public void saveCacheData(String cacheKey, Object data) {
+        redisTemplate.opsForValue().set(cacheKey, data);
     }
 }

--- a/src/main/java/aws/retrospective/resolver/CustomCacheResolver.java
+++ b/src/main/java/aws/retrospective/resolver/CustomCacheResolver.java
@@ -1,0 +1,23 @@
+package aws.retrospective.resolver;
+
+import java.util.Collection;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.interceptor.CacheOperationInvocationContext;
+import org.springframework.cache.interceptor.CacheResolver;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomCacheResolver implements CacheResolver {
+
+    private final CacheManager cacheManager;
+
+    @Override
+    public Collection<? extends Cache> resolveCaches(CacheOperationInvocationContext<?> context) {
+        String cacheName = context.getOperation().getCacheNames().iterator().next();
+        return Collections.singleton(cacheManager.getCache(cacheName));
+    }
+}

--- a/src/main/java/aws/retrospective/service/SectionService.java
+++ b/src/main/java/aws/retrospective/service/SectionService.java
@@ -22,10 +22,12 @@ import aws.retrospective.entity.TemplateSection;
 import aws.retrospective.entity.User;
 import aws.retrospective.exception.custom.ForbiddenAccessException;
 import aws.retrospective.repository.ActionItemRepository;
+import aws.retrospective.repository.CacheRepository;
 import aws.retrospective.repository.KudosTargetRepository;
 import aws.retrospective.repository.LikesRepository;
 import aws.retrospective.repository.NotificationRepository;
 import aws.retrospective.repository.RetrospectiveRepository;
+import aws.retrospective.repository.SectionCacheRepository;
 import aws.retrospective.repository.SectionRepository;
 import aws.retrospective.repository.TeamRepository;
 import aws.retrospective.repository.TemplateSectionRepository;
@@ -35,6 +37,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -56,9 +59,12 @@ public class SectionService {
     private final NotificationRepository notificationRepository;
     private final RedisTemplate<String, Object> redisTemplate;
 
+    @Qualifier("sectionCacheRepository")
+    private final CacheRepository cacheRepository;
+
     // 회고 카드 전체 조회
     @Transactional(readOnly = true)
-    @Cacheable(value = "sectionInRetrospective-cache", key = "#request.retrospectiveId")
+    @Cacheable(value = SectionCacheRepository.CACHE_KEY, key = "#request.retrospectiveId")
     public List<GetSectionsResponseDto> getSections(GetSectionsRequestDto request) {
         Retrospective findRetrospective = getRetrospective(request.getRetrospectiveId());
 
@@ -127,7 +133,8 @@ public class SectionService {
             findSection.increaseSectionLikes(); // 좋아요 기록 저장
 
             // 댓글 알림 생성
-            Notification notification = createNotification(findSection, findSection.getRetrospective(),
+            Notification notification = createNotification(findSection,
+                findSection.getRetrospective(),
                 user, findSection.getUser(), createLikes);
             notificationRepository.save(notification);
         } else {
@@ -194,7 +201,7 @@ public class SectionService {
         /**
          * Kudos 정보가 없을 때는 새로 생성하고, 있을 때는 사용자를 지정(변경)한다.
          */
-        if(findKudosTarget == null) {
+        if (findKudosTarget == null) {
             KudosTarget createNewKudosTarget = assignKudos(section, targetUser);
             return convertAssignKudosResponse(createNewKudosTarget);
         }
@@ -227,10 +234,11 @@ public class SectionService {
 
     /**
      * Section 생성
-     * @param sectionContent 회고 카드 내용
+     *
+     * @param sectionContent  회고 카드 내용
      * @param templateSection 회고 카드의 템플릿 (ex. Keep, Problem, Try)
-     * @param retrospective 회고 카드가 속한 회고 보드
-     * @param user 회고 카드를 작성한 사용자
+     * @param retrospective   회고 카드가 속한 회고 보드
+     * @param user            회고 카드를 작성한 사용자
      * @return
      */
     private Section createSection(String sectionContent, TemplateSection templateSection,
@@ -264,21 +272,24 @@ public class SectionService {
 
     /**
      * 칭찬 대상을 지정한다.
+     *
      * @param section 칭찬 대상을 지정할 Section
-     * @param user 칭찬 대상
+     * @param user    칭찬 대상
      * @return
      */
     private KudosTarget assignKudos(Section section, User user) {
         return kudosRepository.save(KudosTarget.createKudosTarget(section, user));
     }
 
-    private void validateTemplateMatch(Retrospective retrospective, TemplateSection templateSection) {
-        if(retrospective.isNotSameTemplate(templateSection.getTemplate())) {
+    private void validateTemplateMatch(Retrospective retrospective,
+        TemplateSection templateSection) {
+        if (retrospective.isNotSameTemplate(templateSection.getTemplate())) {
             throw new IllegalArgumentException("회고 템플릿 정보가 일치하지 않습니다.");
         }
     }
 
-    private static CreateSectionResponseDto convertCreateSectionResponseDto(CreateSectionDto request,
+    private static CreateSectionResponseDto convertCreateSectionResponseDto(
+        CreateSectionDto request,
         Section createSection) {
         return CreateSectionResponseDto.builder()
             .id(createSection.getId())
@@ -294,7 +305,8 @@ public class SectionService {
 
     /**
      * 회고 카드 수정 응답 Dto 변환
-     * @param sectionId 수정된 회고 카드 ID
+     *
+     * @param sectionId      수정된 회고 카드 ID
      * @param sectionContent 수정된 회고 카드 내용
      */
     private static EditSectionResponseDto convertUpdateSectionResponseDto(Long sectionId,
@@ -305,6 +317,7 @@ public class SectionService {
 
     /**
      * Section 삭제
+     *
      * @param section 삭제할 회고 카드
      */
     public void deleteSection(Section section) {
@@ -341,9 +354,10 @@ public class SectionService {
 
     /**
      * Action Item 생성 및 사용자 지정
-     * @param user Action Item에 지정할 사용자
-     * @param team 팀 정보 (개인 : null)
-     * @param section Action Item을 지정할 회고 카드
+     *
+     * @param user          Action Item에 지정할 사용자
+     * @param team          팀 정보 (개인 : null)
+     * @param section       Action Item을 지정할 회고 카드
      * @param retrospective Action Item을 지정할 회고 보드
      */
     private void assignActionItem(User user, Team team, Section section,
@@ -362,7 +376,8 @@ public class SectionService {
         return kudosRepository.findBySectionId(section.getId());
     }
 
-    private IncreaseSectionLikesResponseDto convertIncreaseSectionLikesResponseDto(Section section) {
+    private IncreaseSectionLikesResponseDto convertIncreaseSectionLikesResponseDto(
+        Section section) {
         return new IncreaseSectionLikesResponseDto(section.getId(), section.getLikeCnt());
     }
 
@@ -387,7 +402,7 @@ public class SectionService {
     }
 
     private void updateCacheWithNewSection(Long retrospectiveId, Section newSection, User user) {
-        String cacheKey = "sectionsInRetrospective-cache::" + retrospectiveId;
+        String cacheKey = String.format("%s::%d", cacheRepository.getCacheKey(), retrospectiveId);
 
         // 캐싱된 데이터를 가져온다.
         List<GetSectionsResponseDto> cachingData = (List<GetSectionsResponseDto>) redisTemplate.opsForValue()

--- a/src/main/java/aws/retrospective/service/SectionService.java
+++ b/src/main/java/aws/retrospective/service/SectionService.java
@@ -58,10 +58,6 @@ public class SectionService {
     private final UserRepository userRepository;
     private final KudosTargetRepository kudosRepository;
     private final NotificationRepository notificationRepository;
-
-    @Qualifier("sectionCacheRepository")
-    private final CacheRepository<List<GetSectionsResponseDto>> cacheRepository;
-
     private final ApplicationEventPublisher eventPublisher;
 
     // 회고 카드 전체 조회

--- a/src/main/java/aws/retrospective/service/SectionService.java
+++ b/src/main/java/aws/retrospective/service/SectionService.java
@@ -57,10 +57,9 @@ public class SectionService {
     private final UserRepository userRepository;
     private final KudosTargetRepository kudosRepository;
     private final NotificationRepository notificationRepository;
-    private final RedisTemplate<String, Object> redisTemplate;
 
     @Qualifier("sectionCacheRepository")
-    private final CacheRepository cacheRepository;
+    private final CacheRepository<List<GetSectionsResponseDto>> cacheRepository;
 
     // 회고 카드 전체 조회
     @Transactional(readOnly = true)
@@ -405,13 +404,12 @@ public class SectionService {
         String cacheKey = String.format("%s::%d", cacheRepository.getCacheKey(), retrospectiveId);
 
         // 캐싱된 데이터를 가져온다.
-        List<GetSectionsResponseDto> cachingData = (List<GetSectionsResponseDto>) redisTemplate.opsForValue()
-            .get(cacheKey);
+        List<GetSectionsResponseDto> cachingData = cacheRepository.getCacheDate(cacheKey);
 
         // 캐싱된 값이 존재할 경우 생성된 회고 카드를 추가한다.
         if (cachingData != null && !cachingData.isEmpty()) {
             cachingData.add(GetSectionsResponseDto.from(newSection, user));
-            redisTemplate.opsForValue().set(cacheKey, cachingData);
+            cacheRepository.saveCacheData(cacheKey, cachingData);
         }
     }
 }

--- a/src/main/java/aws/retrospective/service/SectionService.java
+++ b/src/main/java/aws/retrospective/service/SectionService.java
@@ -39,7 +39,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,7 +62,7 @@ public class SectionService {
 
     // 회고 카드 전체 조회
     @Transactional(readOnly = true)
-    @Cacheable(value = SectionCacheRepository.CACHE_KEY, key = "#request.retrospectiveId")
+    @Cacheable(value = SectionCacheRepository.CACHE_KEY, key = "#request.retrospectiveId", cacheResolver = "customCacheResolver")
     public List<GetSectionsResponseDto> getSections(GetSectionsRequestDto request) {
         Retrospective findRetrospective = getRetrospective(request.getRetrospectiveId());
 

--- a/src/main/java/aws/retrospective/service/SectionService.java
+++ b/src/main/java/aws/retrospective/service/SectionService.java
@@ -58,7 +58,7 @@ public class SectionService {
 
     // 회고 카드 전체 조회
     @Transactional(readOnly = true)
-    @Cacheable(value = "sections", key = "#request.retrospectiveId")
+    @Cacheable(value = "sectionInRetrospective-cache", key = "#request.retrospectiveId")
     public List<GetSectionsResponseDto> getSections(GetSectionsRequestDto request) {
         Retrospective findRetrospective = getRetrospective(request.getRetrospectiveId());
 
@@ -387,7 +387,7 @@ public class SectionService {
     }
 
     private void updateCacheWithNewSection(Long retrospectiveId, Section newSection, User user) {
-        String cacheKey = "sections::" + retrospectiveId;
+        String cacheKey = "sectionsInRetrospective-cache::" + retrospectiveId;
 
         // 캐싱된 데이터를 가져온다.
         List<GetSectionsResponseDto> cachingData = (List<GetSectionsResponseDto>) redisTemplate.opsForValue()

--- a/src/main/java/aws/retrospective/util/ObjectMapperFactory.java
+++ b/src/main/java/aws/retrospective/util/ObjectMapperFactory.java
@@ -6,17 +6,18 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public class ObjectMapperFactory {
 
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
-  static {
-    objectMapper.registerModule(new JavaTimeModule()); // Java 8 날짜/시간 모듈 등록
-    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식 사용
-  }
+    static {
+        objectMapper.registerModule(new JavaTimeModule()); // Java 8 날짜/시간 모듈 등록
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식 사용
+    }
 
-  public static ObjectMapper getInstance() {
-    return objectMapper;
-  }
+    public static ObjectMapper getInstance() {
+        return objectMapper;
+    }
 
-  private ObjectMapperFactory() {}
+    private ObjectMapperFactory() {
+    }
 
 }

--- a/src/main/java/aws/retrospective/util/ObjectMapperFactory.java
+++ b/src/main/java/aws/retrospective/util/ObjectMapperFactory.java
@@ -17,8 +17,6 @@ public class ObjectMapperFactory {
     return objectMapper;
   }
 
-  private ObjectMapperFactory() {
-    throw new IllegalStateException("ObjectMapperFactory class");
-  }
+  private ObjectMapperFactory() {}
 
 }

--- a/src/main/java/aws/retrospective/util/ObjectMapperFactory.java
+++ b/src/main/java/aws/retrospective/util/ObjectMapperFactory.java
@@ -1,0 +1,24 @@
+package aws.retrospective.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class ObjectMapperFactory {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  static {
+    objectMapper.registerModule(new JavaTimeModule()); // Java 8 날짜/시간 모듈 등록
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식 사용
+  }
+
+  public static ObjectMapper getInstance() {
+    return objectMapper;
+  }
+
+  private ObjectMapperFactory() {
+    throw new IllegalStateException("ObjectMapperFactory class");
+  }
+
+}

--- a/src/test/java/aws/retrospective/service/CommentServiceTest.java
+++ b/src/test/java/aws/retrospective/service/CommentServiceTest.java
@@ -12,11 +12,13 @@ import aws.retrospective.dto.DeleteCommentRequestDto;
 import aws.retrospective.dto.UpdateCommentRequestDto;
 import aws.retrospective.dto.UpdateCommentResponseDto;
 import aws.retrospective.entity.Comment;
+import aws.retrospective.entity.Retrospective;
 import aws.retrospective.entity.Section;
 import aws.retrospective.entity.User;
 import aws.retrospective.repository.CommentRepository;
 import aws.retrospective.repository.NotificationRepository;
 import aws.retrospective.repository.SectionRepository;
+import aws.retrospective.util.TestUtil;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,6 +39,8 @@ class CommentServiceTest {
     private CommentRepository commentRepository;
     @Mock
     private NotificationRepository notificationRepository;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
     @InjectMocks
     private CommentService commentService;
 
@@ -47,8 +52,12 @@ class CommentServiceTest {
         User user = createUser();
         ReflectionTestUtils.setField(user, "id", userId);
 
+        Retrospective retrospective = TestUtil.createRetrospective(TestUtil.createTemplate(), user,
+            TestUtil.createTeam());
+
         Long sectionId = 1L;
         Section section = createSection();
+        ReflectionTestUtils.setField(section, "retrospective", retrospective);
         ReflectionTestUtils.setField(section, "id", sectionId);
 
         Comment mockComment = createComment();
@@ -72,8 +81,13 @@ class CommentServiceTest {
     void deleteCommentSuccessTest() {
         //given
         User user = createUser();
+
+        Retrospective retrospective = TestUtil.createRetrospective(TestUtil.createTemplate(), user,
+            TestUtil.createTeam());
+
         ReflectionTestUtils.setField(user, "id", 1L);
         Section section = createSection();
+        ReflectionTestUtils.setField(section, "retrospective", retrospective);
 
         Long commentId = 1L;
         Comment comment = createComment(user, section);
@@ -121,10 +135,16 @@ class CommentServiceTest {
         User longinedUser = createUser();
         ReflectionTestUtils.setField(longinedUser, "id", userId);
 
+        Retrospective retrospective = TestUtil.createRetrospective(TestUtil.createTemplate(), longinedUser,
+            TestUtil.createTeam());
+        Section section = createSection();
+        ReflectionTestUtils.setField(section, "retrospective", retrospective);
+
         Long commentId = 1L;
         Comment comment = createComment();
         ReflectionTestUtils.setField(comment, "id", commentId);
         ReflectionTestUtils.setField(comment, "user", longinedUser);
+        ReflectionTestUtils.setField(comment, "section", section);
         when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
 
         //when

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -54,7 +54,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -81,8 +80,6 @@ class SectionServiceTest {
     @Mock
     NotificationRepository notificationRepository;
     @Mock
-    RedisTemplate<String, Object> redisTemplate;
-    @Mock
     CacheRepository cacheRepository;
     @InjectMocks
     SectionService sectionService;
@@ -103,11 +100,6 @@ class SectionServiceTest {
         ReflectionTestUtils.setField(retrospective, "id", retrospectiveId);
         when(retrospectiveRepository.findById(retrospectiveId)).thenReturn(
             Optional.of(retrospective));
-
-        // TODO RedisTemplate 추상화 처리
-        ValueOperations<String, Object> valueOperations = mock(ValueOperations.class);
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        when(valueOperations.get(any())).thenReturn(null);
 
         Long templateSectionId = 1L;
         TemplateSection templateSection = createTemplateSection(kptTemplate);

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -80,8 +80,6 @@ class SectionServiceTest {
     @Mock
     NotificationRepository notificationRepository;
     @Mock
-    CacheRepository cacheRepository;
-    @Mock
     ApplicationEventPublisher eventPublisher;
     @InjectMocks
     SectionService sectionService;

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -34,7 +34,6 @@ import aws.retrospective.entity.TemplateSection;
 import aws.retrospective.entity.User;
 import aws.retrospective.exception.custom.ForbiddenAccessException;
 import aws.retrospective.repository.ActionItemRepository;
-import aws.retrospective.repository.CacheRepository;
 import aws.retrospective.repository.KudosTargetRepository;
 import aws.retrospective.repository.LikesRepository;
 import aws.retrospective.repository.NotificationRepository;
@@ -169,8 +168,12 @@ class SectionServiceTest {
         User user = createUser();
         ReflectionTestUtils.setField(user, "id", userId);
 
+        Retrospective retrospective = createRetrospective(createTemplate(), createUser(),
+            createTeam());
+
         Long sectionId = 1L;
         Section section = createSection(user);
+        ReflectionTestUtils.setField(section, "retrospective", retrospective);
         ReflectionTestUtils.setField(section, "id", sectionId);
         when(sectionRepository.findById(sectionId)).thenReturn(Optional.of(section));
 
@@ -196,8 +199,12 @@ class SectionServiceTest {
         User user = createUser();
         ReflectionTestUtils.setField(user, "id", userId);
 
+        Retrospective retrospective = createRetrospective(createTemplate(), createUser(),
+            createTeam());
+
         Long sectionId = 1L;
         Section section = createSection(user);
+        ReflectionTestUtils.setField(section, "retrospective", retrospective);
         ReflectionTestUtils.setField(section, "id", sectionId);
         ReflectionTestUtils.setField(section, "likeCnt", 2);
         when(sectionRepository.findById(sectionId)).thenReturn(Optional.of(section));
@@ -225,8 +232,12 @@ class SectionServiceTest {
         User loginedUser = createUser();
         ReflectionTestUtils.setField(loginedUser, "id", userId);
 
+        Retrospective retrospective = createRetrospective(createTemplate(), createUser(),
+            createTeam());
+
         Long sectionId = 1L;
         Section section = createSection(loginedUser);
+        ReflectionTestUtils.setField(section, "retrospective", retrospective);
         ReflectionTestUtils.setField(section, "id", sectionId);
         when(sectionRepository.findById(sectionId)).thenReturn(Optional.of(section));
 
@@ -471,8 +482,12 @@ class SectionServiceTest {
     @DisplayName("Kudos Section에 이미 지정된 사람을 다른 사람으로 바꿀 수 있다.")
     void assignKudosSection_exist() {
         //given
+        Retrospective retrospective = createRetrospective(createTemplate(), createUser(),
+            createTeam());
+
         Long sectionId = 1L;
         Section mockSection = mock(Section.class);
+        when(mockSection.getRetrospective()).thenReturn(retrospective);
         when(mockSection.getId()).thenReturn(sectionId);
         when(sectionRepository.findById(sectionId)).thenReturn(Optional.of(mockSection));
         when(mockSection.isNotKudosTemplate()).thenReturn(false);

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -34,6 +34,7 @@ import aws.retrospective.entity.TemplateSection;
 import aws.retrospective.entity.User;
 import aws.retrospective.exception.custom.ForbiddenAccessException;
 import aws.retrospective.repository.ActionItemRepository;
+import aws.retrospective.repository.CacheRepository;
 import aws.retrospective.repository.KudosTargetRepository;
 import aws.retrospective.repository.LikesRepository;
 import aws.retrospective.repository.NotificationRepository;
@@ -81,6 +82,8 @@ class SectionServiceTest {
     NotificationRepository notificationRepository;
     @Mock
     RedisTemplate<String, Object> redisTemplate;
+    @Mock
+    CacheRepository cacheRepository;
     @InjectMocks
     SectionService sectionService;
 
@@ -101,6 +104,7 @@ class SectionServiceTest {
         when(retrospectiveRepository.findById(retrospectiveId)).thenReturn(
             Optional.of(retrospective));
 
+        // TODO RedisTemplate 추상화 처리
         ValueOperations<String, Object> valueOperations = mock(ValueOperations.class);
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(any())).thenReturn(null);

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -53,7 +53,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -81,6 +81,8 @@ class SectionServiceTest {
     NotificationRepository notificationRepository;
     @Mock
     CacheRepository cacheRepository;
+    @Mock
+    ApplicationEventPublisher eventPublisher;
     @InjectMocks
     SectionService sectionService;
 

--- a/src/test/java/aws/retrospective/service/SectionServiceTest.java
+++ b/src/test/java/aws/retrospective/service/SectionServiceTest.java
@@ -52,6 +52,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -77,6 +79,8 @@ class SectionServiceTest {
     KudosTargetRepository kudosRepository;
     @Mock
     NotificationRepository notificationRepository;
+    @Mock
+    RedisTemplate<String, Object> redisTemplate;
     @InjectMocks
     SectionService sectionService;
 
@@ -96,6 +100,10 @@ class SectionServiceTest {
         ReflectionTestUtils.setField(retrospective, "id", retrospectiveId);
         when(retrospectiveRepository.findById(retrospectiveId)).thenReturn(
             Optional.of(retrospective));
+
+        ValueOperations<String, Object> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(any())).thenReturn(null);
 
         Long templateSectionId = 1L;
         TemplateSection templateSection = createTemplateSection(kptTemplate);


### PR DESCRIPTION
## 개요
- #301 

## 변경 사항
- 회고 보드에 작성된 모든 회고 카드 조회 시에 캐싱된 값을 가져올 수 있도록 한다.
- 새로운 회고 카드가 작성되었을 때 기존에 캐싱된 데이터가 있다면, 캐싱된 데이터에 새로운 회고 카드를 추가한다.

## 테스트

- [ ] 어떻게 이 변경 사항을 테스트했는지
- [ ] 어떤 환경에서 테스트가 이루어졌는지 (예: 로컬 개발 환경, 스테이징 환경)

## 배포 계획

- 배포 전 필수 확인 사항이 있다면 적어주세요!